### PR TITLE
Add in-memory caching for historical stock data

### DIFF
--- a/src/app/api/scan/route.ts
+++ b/src/app/api/scan/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { scanMultipleStocks } from "@/lib/scanner";
 import { getWatchlist, addAlert, getAlerts } from "@/lib/store";
-import { getMarketStatus } from "@/lib/nse-client";
+import { getMarketStatus, getHistoricalCacheStats } from "@/lib/nse-client";
 import type { Alert, ScanResponse } from "@/lib/types";
 
 export const dynamic = "force-dynamic";
@@ -44,6 +44,7 @@ export async function POST(request: Request) {
       alerts: getAlerts(),
       scannedAt: new Date().toISOString(),
       marketOpen,
+      cacheStats: getHistoricalCacheStats(),
     };
 
     return NextResponse.json(response);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -48,4 +48,9 @@ export interface ScanResponse {
   alerts: Alert[];
   scannedAt: string;
   marketOpen: boolean;
+  cacheStats?: {
+    size: number;
+    symbols: string[];
+    date: string;
+  };
 }


### PR DESCRIPTION
## Summary
Implements an in-memory cache for historical stock data to reduce redundant NSE API calls when the same symbols are scanned multiple times within a single trading day.

## Key Changes
- **Historical data caching**: Added `historicalCache` Map to store fetched historical data with validation based on:
  - Calendar date (IST timezone to match NSE trading day boundaries)
  - Requested lookback period (`days` parameter)
- **Cache validation**: `getHistoricalData()` now checks cache before making API calls and returns cached data if the date and days parameter match
- **Cache statistics endpoint**: Added `getHistoricalCacheStats()` function to expose cache state (size, symbols, current date)
- **IST timezone handling**: Implemented `todayDateString()` utility that uses Asia/Kolkata timezone to ensure cache rolls over at Indian midnight, aligning with NSE's trading day boundaries
- **API response enhancement**: Updated `ScanResponse` type to include optional `cacheStats` field and modified `/api/scan` endpoint to include cache statistics in responses

## Implementation Details
- Cache entries are keyed by stock symbol and store the cached date, requested days, and DayData array
- The cache is automatically invalidated when the calendar date changes (in IST)
- Different lookback windows (e.g., 10-day vs 20-day scans) are cached separately to support varied scanning strategies
- Cache statistics are included in scan API responses for monitoring and debugging purposes

https://claude.ai/code/session_01QiQtv1Tkumj7uNUPVNqXeS