### PR TITLE
Make stale intraday data an explicit state instead of a silent fallback

### DIFF
--- a/src/app/api/scan/route.ts
+++ b/src/app/api/scan/route.ts
@@ -14,7 +14,7 @@ export async function POST(request: Request) {
     const watchlist = getWatchlist();
     const marketOpen = await getMarketStatus().catch(() => false);
 
-    const results = await scanMultipleStocks(watchlist, useIntraday);
+    const results = await scanMultipleStocks(watchlist, useIntraday, marketOpen);
 
     const newAlerts: Alert[] = [];
     for (const result of results) {

--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -97,6 +97,7 @@ export function Dashboard({
   }, []);
 
   const triggeredCount = results.filter((r) => r.triggered).length;
+  const staleCount = results.filter((r) => r.dataSource === "stale").length;
   const scannedCount = results.length;
 
   return (
@@ -110,7 +111,7 @@ export function Dashboard({
 
       <main className="mx-auto max-w-7xl px-6 py-8">
         {scannedCount > 0 && (
-          <div className="mb-8 grid grid-cols-3 gap-3 animate-fade-in">
+          <div className={`mb-8 grid gap-3 animate-fade-in ${staleCount > 0 ? "grid-cols-4" : "grid-cols-3"}`}>
             <StatCard
               label="Stocks Scanned"
               value={scannedCount.toString()}
@@ -141,6 +142,18 @@ export function Dashboard({
                 </svg>
               }
             />
+            {staleCount > 0 && (
+              <StatCard
+                label="Stale Data"
+                value={staleCount.toString()}
+                warning
+                icon={
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                    <path d="M12 9v4M12 17h.01M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+                  </svg>
+                }
+              />
+            )}
           </div>
         )}
 
@@ -212,6 +225,7 @@ export function Dashboard({
                       todayClose: 0,
                       todayChange: 0,
                       scannedAt: "",
+                      dataSource: "historical",
                     }
                   }
                   onRemove={removeStock}
@@ -257,25 +271,35 @@ function StatCard({
   value,
   icon,
   accent,
+  warning,
 }: {
   label: string;
   value: string;
   icon: React.ReactNode;
   accent?: boolean;
+  warning?: boolean;
 }) {
   return (
     <div className={`flex items-center gap-3 rounded-xl border p-4 transition-colors ${
-      accent
-        ? "border-accent/20 bg-accent/[0.04]"
-        : "border-surface-border bg-surface-raised"
+      warning
+        ? "border-warn/20 bg-warn/[0.04]"
+        : accent
+          ? "border-accent/20 bg-accent/[0.04]"
+          : "border-surface-border bg-surface-raised"
     }`}>
       <div className={`flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg ${
-        accent ? "bg-accent/15 text-accent" : "bg-surface-overlay text-text-muted"
+        warning
+          ? "bg-warn/15 text-warn"
+          : accent
+            ? "bg-accent/15 text-accent"
+            : "bg-surface-overlay text-text-muted"
       }`}>
         {icon}
       </div>
       <div>
-        <p className={`text-xl font-bold tabular-nums tracking-tight ${accent ? "text-accent" : ""}`}>
+        <p className={`text-xl font-bold tabular-nums tracking-tight ${
+          warning ? "text-warn" : accent ? "text-accent" : ""
+        }`}>
           {value}
         </p>
         <p className="text-[11px] text-text-muted">{label}</p>

--- a/src/components/stock-card.tsx
+++ b/src/components/stock-card.tsx
@@ -10,19 +10,26 @@ export function StockCard({
   onRemove: (symbol: string) => void;
 }) {
   const hasData = result.todayHigh > 0;
-  const highBreaks = hasData && result.todayHigh > result.prevMaxHigh;
-  const volBreaks = hasData && result.todayVolume > result.prevMaxVolume;
+  const isStale = result.dataSource === "stale";
+  const isLive = result.dataSource === "live";
+  const highBreaks = hasData && !isStale && result.todayHigh > result.prevMaxHigh;
+  const volBreaks = hasData && !isStale && result.todayVolume > result.prevMaxVolume;
 
   return (
     <div
       className={`group relative overflow-hidden rounded-2xl border p-5 transition-all duration-300 hover:-translate-y-1 ${
-        result.triggered
-          ? "border-accent/30 card-glow bg-surface-raised"
-          : "border-surface-border bg-surface-raised hover:border-surface-border/80 hover:shadow-xl hover:shadow-black/20"
+        isStale
+          ? "border-warn/30 bg-surface-raised"
+          : result.triggered
+            ? "border-accent/30 card-glow bg-surface-raised"
+            : "border-surface-border bg-surface-raised hover:border-surface-border/80 hover:shadow-xl hover:shadow-black/20"
       }`}
     >
-      {result.triggered && (
+      {result.triggered && !isStale && (
         <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-accent/60 to-transparent" />
+      )}
+      {isStale && (
+        <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-warn/60 to-transparent" />
       )}
 
       <button
@@ -53,6 +60,19 @@ export function StockCard({
                 <span className="inline-flex items-center gap-1 rounded-md bg-accent/15 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-accent">
                   <span className="h-1 w-1 rounded-full bg-accent animate-pulse" />
                   Breakout
+                </span>
+              )}
+              {isLive && (
+                <span className="inline-flex items-center gap-1 rounded-md bg-accent/10 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-accent/70">
+                  Live
+                </span>
+              )}
+              {isStale && (
+                <span className="inline-flex items-center gap-1 rounded-md bg-warn/15 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-warn">
+                  <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3">
+                    <path d="M12 9v4M12 17h.01" />
+                  </svg>
+                  Stale
                 </span>
               )}
             </div>
@@ -109,7 +129,15 @@ export function StockCard({
         </div>
       )}
 
-      {hasData && (
+      {hasData && isStale && (
+        <div className="mt-4 rounded-lg border border-warn/20 bg-warn/[0.06] px-3 py-2">
+          <p className="text-[11px] font-medium text-warn">
+            Live data unavailable — showing last historical candle. Breakout detection paused for this stock.
+          </p>
+        </div>
+      )}
+
+      {hasData && !isStale && (
         <div className="mt-4 flex gap-2">
           <StatusPill active={highBreaks} label="High Break" />
           <StatusPill active={volBreaks} label="Vol Break" />

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -12,6 +12,8 @@ export interface DayData {
   volume: number;
 }
 
+export type DataSource = "live" | "historical" | "stale";
+
 export interface ScanResult {
   symbol: string;
   name: string;
@@ -25,6 +27,7 @@ export interface ScanResult {
   todayClose: number;
   todayChange: number;
   scannedAt: string;
+  dataSource: DataSource;
 }
 
 export interface Alert {


### PR DESCRIPTION
When intraday mode is on and the live NSE fetch fails while the market is open, the scanner now marks results as dataSource:"stale" instead of quietly falling back to the last historical candle. Stale results have breakout triggers suppressed to avoid false positives/negatives, and the UI shows a warning badge + inline message per affected stock card plus a "Stale Data" count in the stats row.

Three data sources are now tracked on every ScanResult:
  - "live"       — real-time intraday data fetched successfully
  - "historical" — last completed candle (daily mode or market closed)
  - "stale"      — intraday requested + market open + live fetch failed

https://claude.ai/code/session_01QiQtv1Tkumj7uNUPVNqXeS