### PR TITLE
Add Close Watch auto-check feature for starred stocks

### DIFF
--- a/src/app/api/scan/route.ts
+++ b/src/app/api/scan/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { scanMultipleStocks } from "@/lib/scanner";
-import { getWatchlist, addAlert, getAlerts } from "@/lib/store";
+import { getWatchlist, getCloseWatchStocks, addAlert, getAlerts } from "@/lib/store";
 import { getMarketStatus, getHistoricalCacheStats } from "@/lib/nse-client";
 import { logger } from "@/lib/logger";
 import type { Alert, ScanResponse } from "@/lib/types";
@@ -11,9 +11,10 @@ export async function POST(request: Request) {
   try {
     const body = await request.json().catch(() => ({}));
     const useIntraday = body.intraday === true;
+    const closeWatchOnly = body.closeWatchOnly === true;
 
-    const watchlist = getWatchlist();
-    logger.api(`POST /api/scan → ${watchlist.length} stocks, intraday=${useIntraday}`, { stockCount: watchlist.length, useIntraday }, 'ScanRoute');
+    const watchlist = closeWatchOnly ? getCloseWatchStocks() : getWatchlist();
+    logger.api(`POST /api/scan → ${watchlist.length} stocks, intraday=${useIntraday}, closeWatchOnly=${closeWatchOnly}`, { stockCount: watchlist.length, useIntraday, closeWatchOnly }, 'ScanRoute');
 
     const scanStart = Date.now();
     const marketOpen = await getMarketStatus().catch(() => false);

--- a/src/components/stock-card.tsx
+++ b/src/components/stock-card.tsx
@@ -5,9 +5,13 @@ import type { ScanResult } from "@/lib/types";
 export function StockCard({
   result,
   onRemove,
+  closeWatch,
+  onToggleCloseWatch,
 }: {
   result: ScanResult;
   onRemove: (symbol: string) => void;
+  closeWatch: boolean;
+  onToggleCloseWatch: (symbol: string) => void;
 }) {
   const hasData = result.todayHigh > 0;
   const isStale = result.dataSource === "stale";
@@ -32,17 +36,39 @@ export function StockCard({
         <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-warn/60 to-transparent" />
       )}
 
-      <button
-        onClick={() => onRemove(result.symbol)}
-        className="absolute right-3 top-3 flex h-7 w-7 items-center justify-center rounded-lg text-text-muted opacity-0 transition-all duration-200 hover:bg-danger-muted hover:text-danger group-hover:opacity-100"
-        aria-label={`Remove ${result.symbol}`}
-      >
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-          <path d="M18 6 6 18M6 6l12 12" />
-        </svg>
-      </button>
+      <div className="absolute right-3 top-3 flex items-center gap-1">
+        <button
+          onClick={() => onToggleCloseWatch(result.symbol)}
+          className={`flex h-7 w-7 items-center justify-center rounded-lg transition-all duration-200 ${
+            closeWatch
+              ? "text-amber-400 opacity-100 hover:bg-amber-400/15"
+              : "text-text-muted opacity-0 hover:bg-surface-overlay hover:text-amber-400 group-hover:opacity-100"
+          }`}
+          aria-label={`${closeWatch ? "Remove from" : "Add to"} close watch`}
+          title={closeWatch ? "Remove from Close Watch" : "Add to Close Watch"}
+        >
+          {closeWatch ? (
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="1">
+              <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+            </svg>
+          ) : (
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+            </svg>
+          )}
+        </button>
+        <button
+          onClick={() => onRemove(result.symbol)}
+          className="flex h-7 w-7 items-center justify-center rounded-lg text-text-muted opacity-0 transition-all duration-200 hover:bg-danger-muted hover:text-danger group-hover:opacity-100"
+          aria-label={`Remove ${result.symbol}`}
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M18 6 6 18M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
 
-      <div className="flex items-start justify-between pr-6">
+      <div className="flex items-start justify-between pr-16">
         <div className="flex items-center gap-3">
           <div
             className={`flex h-10 w-10 items-center justify-center rounded-xl text-xs font-bold transition-colors ${

--- a/src/lib/nifty50.ts
+++ b/src/lib/nifty50.ts
@@ -1,6 +1,6 @@
 import type { WatchlistStock } from "./types";
 
-export const NIFTY_50_STOCKS: WatchlistStock[] = [
+export const NIFTY_50_STOCKS: WatchlistStock[] = ([
   { symbol: "ADANIPORTS", name: "Adani Ports & SEZ" },
   { symbol: "APOLLOHOSP", name: "Apollo Hospitals" },
   { symbol: "ASIANPAINT", name: "Asian Paints" },
@@ -51,4 +51,4 @@ export const NIFTY_50_STOCKS: WatchlistStock[] = [
   { symbol: "WIPRO", name: "Wipro" },
   { symbol: "HAL", name: "Hindustan Aeronautics" },
   { symbol: "SHRIRAMFIN", name: "Shriram Finance" },
-];
+] as { symbol: string; name: string }[]).map((s) => ({ ...s, closeWatch: false }));

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -2,11 +2,11 @@ import "server-only";
 import type { Alert, WatchlistStock } from "./types";
 
 const DEFAULT_WATCHLIST: WatchlistStock[] = [
-  { symbol: "INFY", name: "Infosys" },
-  { symbol: "HDFCBANK", name: "HDFC Bank" },
-  { symbol: "SBIN", name: "SBI" },
-  { symbol: "HAL", name: "Hindustan Aeronautics" },
-  { symbol: "RELIANCE", name: "Reliance Industries" },
+  { symbol: "INFY", name: "Infosys", closeWatch: false },
+  { symbol: "HDFCBANK", name: "HDFC Bank", closeWatch: false },
+  { symbol: "SBIN", name: "SBI", closeWatch: false },
+  { symbol: "HAL", name: "Hindustan Aeronautics", closeWatch: false },
+  { symbol: "RELIANCE", name: "Reliance Industries", closeWatch: false },
 ];
 
 let watchlist: WatchlistStock[] = [...DEFAULT_WATCHLIST];
@@ -18,7 +18,7 @@ export function getWatchlist(): WatchlistStock[] {
 
 export function addToWatchlist(stock: WatchlistStock): WatchlistStock[] {
   if (!watchlist.find((s) => s.symbol === stock.symbol)) {
-    watchlist.push(stock);
+    watchlist.push({ ...stock, closeWatch: stock.closeWatch ?? false });
   }
   return getWatchlist();
 }
@@ -26,6 +26,18 @@ export function addToWatchlist(stock: WatchlistStock): WatchlistStock[] {
 export function removeFromWatchlist(symbol: string): WatchlistStock[] {
   watchlist = watchlist.filter((s) => s.symbol !== symbol);
   return getWatchlist();
+}
+
+export function toggleCloseWatch(symbol: string): WatchlistStock[] {
+  const stock = watchlist.find((s) => s.symbol === symbol);
+  if (stock) {
+    stock.closeWatch = !stock.closeWatch;
+  }
+  return getWatchlist();
+}
+
+export function getCloseWatchStocks(): WatchlistStock[] {
+  return watchlist.filter((s) => s.closeWatch);
 }
 
 export function getAlerts(): Alert[] {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,6 +1,7 @@
 export interface WatchlistStock {
   symbol: string;
   name: string;
+  closeWatch: boolean;
 }
 
 export interface DayData {


### PR DESCRIPTION
## Summary
This PR introduces a "Close Watch" feature that allows users to mark specific stocks for continuous monitoring. When enabled, the dashboard automatically scans only these starred stocks every 30 seconds and alerts users when new breakouts occur.

## Key Changes

- **Close Watch Toggle**: Added ability to star/unstar individual stocks via a new button on each stock card. Starred stocks are persisted in the watchlist data structure.

- **Auto-Check Mechanism**: Implemented a 30-second polling system that:
  - Only runs when Close Watch is active AND there are starred stocks
  - Scans exclusively starred stocks (via new `closeWatchOnly` API parameter)
  - Merges results into the main results list without replacing full scan data
  - Deduplicates alerts by tracking state transitions (only notifies on not-triggered → triggered)

- **UI Enhancements**:
  - Added "Auto Watch" toggle button in the header (visible only when starred stocks exist)
  - Shows live indicator with pulsing dot when auto-check is active
  - Displays count of starred stocks next to watchlist count
  - Shows timestamp of last auto-check scan

- **Backend Updates**:
  - Added `toggleCloseWatch` action to `/api/stocks` endpoint
  - Added `closeWatchOnly` parameter to `/api/scan` endpoint
  - Added `getCloseWatchStocks()` store function
  - Updated all watchlist data structures to include `closeWatch` boolean field

- **State Management**: Used refs to track:
  - Previously triggered symbols (for dedup logic)
  - Auto-check timer handle
  - Running state to prevent concurrent scans

## Implementation Details

The auto-check uses a ref-based deduplication system to avoid alert spam: it maintains a set of symbols that were triggered in the previous cycle and only notifies when a symbol transitions from untriggered to triggered. This ensures users are only alerted once per breakout event, not on every 30-second scan.

The feature gracefully handles edge cases: auto-check stops if all starred stocks are removed, and the timer is properly cleaned up when the component unmounts or the feature is toggled off.

https://claude.ai/code/session_015uWUM4qCNUUN6VFH5LMHsN