### PR TITLE
Fix visual distinction, notification spam, and state persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 .next/
 out/
+data/
 .env
 .env.local
 .env.production.local

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "nifty-stock-scanner",
       "version": "1.0.0",
       "dependencies": {
+        "gsap": "^3.14.2",
         "next": "^14.2.0",
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
@@ -3104,6 +3105,12 @@
       "peerDependencies": {
         "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
+    },
+    "node_modules/gsap": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.14.2.tgz",
+      "integrity": "sha512-P8/mMxVLU7o4+55+1TCnQrPmgjPKnwkzkXOK1asnR9Jg2lna4tEY5qBJjMmAaOBDDZWtlRjBXjLa0w53G/uBLA==",
+      "license": "Standard 'no charge' license: https://gsap.com/standard-license."
     },
     "node_modules/has-flag": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "gsap": "^3.14.2",
     "next": "^14.2.0",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,5 +1,10 @@
 import "server-only";
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
+import { join } from "path";
 import type { Alert, WatchlistStock } from "./types";
+
+const DATA_DIR = join(process.cwd(), "data");
+const STATE_FILE = join(DATA_DIR, "state.json");
 
 const DEFAULT_WATCHLIST: WatchlistStock[] = [
   { symbol: "INFY", name: "Infosys", closeWatch: false },
@@ -9,68 +14,133 @@ const DEFAULT_WATCHLIST: WatchlistStock[] = [
   { symbol: "RELIANCE", name: "Reliance Industries", closeWatch: false },
 ];
 
-let watchlist: WatchlistStock[] = [...DEFAULT_WATCHLIST];
-let alerts: Alert[] = [];
+interface PersistedState {
+  watchlist: WatchlistStock[];
+  alerts: Alert[];
+}
+
+let watchlist: WatchlistStock[] | null = null;
+let alerts: Alert[] | null = null;
+
+function ensureLoaded(): void {
+  if (watchlist !== null) return;
+
+  if (!existsSync(DATA_DIR)) {
+    mkdirSync(DATA_DIR, { recursive: true });
+  }
+
+  if (existsSync(STATE_FILE)) {
+    try {
+      const raw = readFileSync(STATE_FILE, "utf-8");
+      const state: PersistedState = JSON.parse(raw);
+      watchlist = Array.isArray(state.watchlist)
+        ? state.watchlist.map((s) => ({
+            symbol: s.symbol,
+            name: s.name,
+            closeWatch: s.closeWatch ?? false,
+          }))
+        : [...DEFAULT_WATCHLIST];
+      alerts = Array.isArray(state.alerts) ? state.alerts : [];
+      return;
+    } catch {
+      // corrupted file — fall through to defaults
+    }
+  }
+
+  watchlist = [...DEFAULT_WATCHLIST];
+  alerts = [];
+}
+
+function persist(): void {
+  try {
+    if (!existsSync(DATA_DIR)) {
+      mkdirSync(DATA_DIR, { recursive: true });
+    }
+    const state: PersistedState = {
+      watchlist: watchlist ?? [],
+      alerts: alerts ?? [],
+    };
+    writeFileSync(STATE_FILE, JSON.stringify(state, null, 2), "utf-8");
+  } catch {
+    // filesystem write failed — state stays in-memory only
+  }
+}
 
 export function getWatchlist(): WatchlistStock[] {
-  return [...watchlist];
+  ensureLoaded();
+  return [...watchlist!];
 }
 
 export function addToWatchlist(stock: WatchlistStock): WatchlistStock[] {
-  if (!watchlist.find((s) => s.symbol === stock.symbol)) {
-    watchlist.push({ ...stock, closeWatch: stock.closeWatch ?? false });
+  ensureLoaded();
+  if (!watchlist!.find((s) => s.symbol === stock.symbol)) {
+    watchlist!.push({ ...stock, closeWatch: stock.closeWatch ?? false });
+    persist();
   }
   return getWatchlist();
 }
 
 export function removeFromWatchlist(symbol: string): WatchlistStock[] {
-  watchlist = watchlist.filter((s) => s.symbol !== symbol);
+  ensureLoaded();
+  watchlist = watchlist!.filter((s) => s.symbol !== symbol);
+  persist();
   return getWatchlist();
 }
 
 export function toggleCloseWatch(symbol: string): WatchlistStock[] {
-  const stock = watchlist.find((s) => s.symbol === symbol);
+  ensureLoaded();
+  const stock = watchlist!.find((s) => s.symbol === symbol);
   if (stock) {
     stock.closeWatch = !stock.closeWatch;
+    persist();
   }
   return getWatchlist();
 }
 
 export function getCloseWatchStocks(): WatchlistStock[] {
-  return watchlist.filter((s) => s.closeWatch);
+  ensureLoaded();
+  return watchlist!.filter((s) => s.closeWatch);
 }
 
 export function getAlerts(): Alert[] {
-  return [...alerts].sort(
+  ensureLoaded();
+  return [...alerts!].sort(
     (a, b) =>
       new Date(b.triggeredAt).getTime() - new Date(a.triggeredAt).getTime()
   );
 }
 
 export function addAlert(alert: Alert): void {
-  const existing = alerts.find(
+  ensureLoaded();
+  const existing = alerts!.find(
     (a) =>
       a.symbol === alert.symbol &&
       a.triggeredAt.slice(0, 10) === alert.triggeredAt.slice(0, 10)
   );
   if (!existing) {
-    alerts.push(alert);
+    alerts!.push(alert);
+    persist();
   }
 }
 
 export function markAlertRead(id: string): void {
-  const alert = alerts.find((a) => a.id === id);
+  ensureLoaded();
+  const alert = alerts!.find((a) => a.id === id);
   if (alert) {
     alert.read = true;
+    persist();
   }
 }
 
 export function markAllAlertsRead(): void {
-  alerts.forEach((a) => {
+  ensureLoaded();
+  alerts!.forEach((a) => {
     a.read = true;
   });
+  persist();
 }
 
 export function getUnreadAlertCount(): number {
-  return alerts.filter((a) => !a.read).length;
+  ensureLoaded();
+  return alerts!.filter((a) => !a.read).length;
 }


### PR DESCRIPTION
1. Close-watch cards now visually stand out:
   - Amber left border strip (gradient)
   - Amber-tinted top edge, avatar, and hover shadow
   - "Watching" badge next to symbol name
   - Subtle amber glow in bottom corner
   - GSAP-powered star toggle animation (scale + rotation bounce)
   - GSAP entrance animation for all cards

2. 5-minute notification cooldown per symbol:
   - Track last notification timestamp per symbol in a ref
   - Skip browser notification if same symbol was notified < 5 min ago
   - Applies to both manual Refresh All and auto-check scans

3. State now persists to data/state.json:
   - Watchlist (including added non-Nifty stocks) and alerts survive server restarts and redeploys
   - Lazy-loaded on first access, written on every mutation
   - Falls back to defaults if file is missing or corrupted
   - data/ directory added to .gitignore

4. Added GSAP dependency for card animations

https://claude.ai/code/session_015uWUM4qCNUUN6VFH5LMHsN