### PR TITLE
Add dev dashboard with activity timeline, system state, and support mode

### DIFF
--- a/src/app/api/activity/route.ts
+++ b/src/app/api/activity/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import { addActivity, getActivity } from "@/lib/activity";
+import { z } from "zod";
+
+export const dynamic = "force-dynamic";
+
+const postSchema = z.object({
+  action: z.string().min(1).max(50),
+  label: z.string().min(1).max(200),
+  cat: z.enum(["user", "system", "warning"]).default("user"),
+  detail: z.record(z.unknown()).optional(),
+});
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const limit = Math.min(parseInt(searchParams.get("limit") || "80"), 200);
+  const events = await getActivity(limit);
+  return NextResponse.json({ events });
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const parsed = postSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.flatten() },
+        { status: 400 }
+      );
+    }
+    const { cat, action, label, detail } = parsed.data;
+    await addActivity(cat, action, label, detail);
+    return NextResponse.json({ ok: true });
+  } catch {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+}

--- a/src/app/api/scan/route.ts
+++ b/src/app/api/scan/route.ts
@@ -2,8 +2,9 @@ import { NextResponse } from "next/server";
 import { scanMultipleStocks } from "@/lib/scanner";
 import { getWatchlist, getCloseWatchStocks, addAlert, getAlerts } from "@/lib/store";
 import { getMarketStatus, getHistoricalCacheStats } from "@/lib/nse-client";
+import { addActivity, setScanMeta } from "@/lib/activity";
 import { logger } from "@/lib/logger";
-import type { Alert, ScanResponse } from "@/lib/types";
+import type { Alert, ScanResponse, ScanMeta } from "@/lib/types";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
@@ -13,13 +14,16 @@ export async function POST(request: Request) {
     const body = await request.json().catch(() => ({}));
     const useIntraday = body.intraday === true;
     const closeWatchOnly = body.closeWatchOnly === true;
+    const scanType: "manual" | "auto" = closeWatchOnly ? "auto" : "manual";
 
-    const watchlist = closeWatchOnly ? getCloseWatchStocks() : getWatchlist();
+    const watchlist = closeWatchOnly
+      ? await getCloseWatchStocks()
+      : await getWatchlist();
     logger.api(
       `Starting scan of ${watchlist.length} stock(s) ${closeWatchOnly ? '(Close Watch only)' : ''}`,
       { stockCount: watchlist.length, useIntraday, closeWatchOnly },
       'Scan API',
-      `A scan was requested for ${watchlist.length} stock(s). ${closeWatchOnly ? 'Only stocks on your Close Watch list are being checked.' : 'All stocks on your watchlist are being scanned.'} ${useIntraday ? 'Using live intraday prices (market hours mode).' : 'Using end-of-day closing prices.'}`,
+      `A scan was requested for ${watchlist.length} stock(s). ${closeWatchOnly ? 'Only stocks on your Close Watch list are being checked.' : 'All stocks on your watchlist are being scanned.'} ${useIntraday ? 'Using live intraday prices.' : 'Using end-of-day closing prices.'}`,
     );
 
     const scanStart = Date.now();
@@ -50,6 +54,53 @@ export async function POST(request: Request) {
       }
     }
 
+    // ── Activity tracking ──────────────────────────────────────────────
+    const staleCount = results.filter((r) => r.dataSource === "stale").length;
+    const liveCount = results.filter((r) => r.dataSource === "live").length;
+    const historicalCount = results.filter((r) => r.dataSource === "historical").length;
+    const closeWatchSymbols = (await getCloseWatchStocks()).map((s) => s.symbol);
+
+    const meta: ScanMeta = {
+      scannedAt: new Date().toISOString(),
+      scanType,
+      marketOpen,
+      stockCount: results.length,
+      triggeredCount: newAlerts.length,
+      staleCount,
+      liveCount,
+      historicalCount,
+      closeWatchSymbols,
+      alertsFired: newAlerts.map((a) => a.symbol),
+    };
+    await setScanMeta(meta);
+
+    await addActivity(
+      "system",
+      scanType === "auto" ? "scan-auto" : "scan-manual",
+      `${scanType === "auto" ? "Auto-scan" : "Manual scan"}: ${results.length} stocks in ${scanDuration}ms` +
+        (newAlerts.length > 0 ? ` — ${newAlerts.length} breakout${newAlerts.length > 1 ? "s" : ""}` : ""),
+      { durationMs: scanDuration, stockCount: results.length, triggeredCount: newAlerts.length, marketOpen, intraday: useIntraday }
+    );
+
+    for (const a of newAlerts) {
+      await addActivity(
+        "system",
+        "alert-fired",
+        `Alert: ${a.symbol} breakout — high +${a.highBreakPercent}%, vol +${a.volumeBreakPercent}%`,
+        { symbol: a.symbol, highBreakPercent: a.highBreakPercent, volumeBreakPercent: a.volumeBreakPercent }
+      );
+    }
+
+    if (staleCount > 0) {
+      const staleSymbols = results.filter((r) => r.dataSource === "stale").map((r) => r.symbol);
+      await addActivity(
+        "warning",
+        "data-stale",
+        `${staleCount} stock${staleCount > 1 ? "s" : ""} returned stale data: ${staleSymbols.join(", ")}`,
+        { symbols: staleSymbols, count: staleCount }
+      );
+    }
+
     const response: ScanResponse = {
       results,
       alerts: await getAlerts(),
@@ -62,7 +113,7 @@ export async function POST(request: Request) {
       `Scan complete in ${scanDuration}ms — ${results.length} stocks, ${newAlerts.length} new alert(s)`,
       { durationMs: scanDuration, stockCount: results.length, alertCount: newAlerts.length, marketOpen },
       'Scan API',
-      `Finished scanning ${results.length} stock(s) in ${(scanDuration / 1000).toFixed(1)} seconds. ${newAlerts.length > 0 ? `⚠️ ${newAlerts.length} stock(s) triggered a breakout alert — their price and volume both exceeded recent highs. Check the alerts panel for details.` : '✅ No breakout signals detected this cycle. All stocks are trading within their normal recent ranges.'} ${marketOpen ? 'Market is currently OPEN.' : 'Market is currently CLOSED — using yesterday\'s closing data.'}`,
+      `Finished scanning ${results.length} stock(s) in ${(scanDuration / 1000).toFixed(1)} seconds. ${newAlerts.length > 0 ? `${newAlerts.length} stock(s) triggered a breakout alert.` : 'No breakout signals detected this cycle.'} ${marketOpen ? 'Market is currently OPEN.' : 'Market is currently CLOSED.'}`,
     );
     return NextResponse.json(response);
   } catch (error) {
@@ -72,8 +123,11 @@ export async function POST(request: Request) {
       `Scan failed: ${message}`,
       { error: message },
       'Scan API',
-      `The entire scan cycle failed and no stocks were analyzed. Error: "${message}". This usually means the NSE India website is unreachable. The system will try again on the next scan cycle.`,
+      `The entire scan cycle failed. Error: "${message}". The system will try again on the next scan cycle.`,
     );
+
+    await addActivity("warning", "scan-error", `Scan failed: ${message}`).catch(() => {});
+
     return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/src/app/api/state/route.ts
+++ b/src/app/api/state/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { getWatchlist, getAlerts } from "@/lib/store";
+import { getScanMeta } from "@/lib/activity";
+import { getMarketStatus, getHistoricalCacheStats } from "@/lib/nse-client";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const [watchlist, alerts, scanMeta, marketOpen, cacheStats] =
+    await Promise.all([
+      getWatchlist(),
+      getAlerts(),
+      getScanMeta(),
+      getMarketStatus().catch(() => false),
+      Promise.resolve(getHistoricalCacheStats()),
+    ]);
+
+  const closeWatchStocks = watchlist.filter((s) => s.closeWatch);
+  const unreadAlerts = alerts.filter((a) => !a.read).length;
+
+  return NextResponse.json({
+    market: { open: marketOpen },
+    watchlist: {
+      total: watchlist.length,
+      closeWatch: closeWatchStocks.length,
+      closeWatchSymbols: closeWatchStocks.map((s) => s.symbol),
+    },
+    alerts: {
+      total: alerts.length,
+      unread: unreadAlerts,
+    },
+    scan: scanMeta,
+    cache: cacheStats,
+    serverTime: new Date().toISOString(),
+  });
+}

--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -305,7 +305,14 @@ export function Dashboard({
           <div className="flex items-center gap-2">
             {closeWatchCount > 0 && (
               <button
-                onClick={() => setAutoCheckActive(!autoCheckActive)}
+                onClick={() => {
+                  const next = !autoCheckActive;
+                  setAutoCheckActive(next);
+                  reportAction(
+                    next ? "autocheck-started" : "autocheck-stopped",
+                    next ? "Started auto-check (30s interval)" : "Stopped auto-check"
+                  );
+                }}
                 className={`flex items-center gap-1.5 rounded-lg border px-3.5 py-2.5 text-xs font-medium transition-all duration-200 ${
                   autoCheckActive
                     ? "border-amber-400/30 bg-amber-400/10 text-amber-400"
@@ -339,7 +346,14 @@ export function Dashboard({
               onScan={runScan}
               loading={scanning}
               intraday={intraday}
-              onToggleIntraday={() => setIntraday(!intraday)}
+              onToggleIntraday={() => {
+                const next = !intraday;
+                setIntraday(next);
+                reportAction(
+                  next ? "intraday-on" : "intraday-off",
+                  next ? "Switched to intraday mode" : "Switched to historical mode"
+                );
+              }}
             />
           </div>
         </div>
@@ -453,6 +467,15 @@ function StatCard({
       </div>
     </div>
   );
+}
+
+/* Fire-and-forget activity reporter for client-side user actions */
+function reportAction(action: string, label: string, detail?: Record<string, unknown>) {
+  fetch("/api/activity", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ cat: "user", action, label, detail }),
+  }).catch(() => {});
 }
 
 const NOTIFY_COOLDOWN_MS = 5 * 60 * 1000; // 5 minutes

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -1,0 +1,123 @@
+import "server-only";
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
+import { join } from "path";
+import { getRedis } from "./redis";
+import type { ActivityEvent, ActivityCategory, ScanMeta } from "./types";
+
+/* ── Keys & limits ──────────────────────────────────────────────────── */
+
+const ACTIVITY_KEY = "nse:activity";
+const SCAN_META_KEY = "nse:scan-meta";
+const MAX_EVENTS = 200;
+
+/* ── Filesystem fallback (local dev) ────────────────────────────────── */
+
+const DATA_DIR = join(process.cwd(), "data");
+const ACTIVITY_FILE = join(DATA_DIR, "activity.json");
+
+interface PersistedActivity {
+  events: ActivityEvent[];
+  scanMeta: ScanMeta | null;
+}
+
+let memEvents: ActivityEvent[] | null = null;
+let memScanMeta: ScanMeta | null = null;
+
+function fsLoad(): void {
+  if (memEvents !== null) return;
+  try {
+    if (!existsSync(DATA_DIR)) mkdirSync(DATA_DIR, { recursive: true });
+    if (existsSync(ACTIVITY_FILE)) {
+      const state: PersistedActivity = JSON.parse(
+        readFileSync(ACTIVITY_FILE, "utf-8")
+      );
+      memEvents = Array.isArray(state.events) ? state.events : [];
+      memScanMeta = state.scanMeta ?? null;
+      return;
+    }
+  } catch {
+    /* corrupted */
+  }
+  memEvents = [];
+  memScanMeta = null;
+}
+
+function fsPersist(): void {
+  try {
+    if (!existsSync(DATA_DIR)) mkdirSync(DATA_DIR, { recursive: true });
+    writeFileSync(
+      ACTIVITY_FILE,
+      JSON.stringify(
+        { events: memEvents ?? [], scanMeta: memScanMeta ?? null },
+        null,
+        2
+      ),
+      "utf-8"
+    );
+  } catch {
+    /* write failed */
+  }
+}
+
+/* ── Internal helpers ───────────────────────────────────────────────── */
+
+async function loadEvents(): Promise<ActivityEvent[]> {
+  const r = getRedis();
+  if (r) return (await r.get<ActivityEvent[]>(ACTIVITY_KEY)) ?? [];
+  fsLoad();
+  return [...memEvents!];
+}
+
+async function saveEvents(events: ActivityEvent[]): Promise<void> {
+  const r = getRedis();
+  if (r) {
+    await r.set(ACTIVITY_KEY, events);
+    return;
+  }
+  memEvents = events;
+  fsPersist();
+}
+
+/* ── Public API ─────────────────────────────────────────────────────── */
+
+export async function addActivity(
+  cat: ActivityCategory,
+  action: string,
+  label: string,
+  detail?: Record<string, unknown>
+): Promise<void> {
+  const event: ActivityEvent = {
+    id: `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+    ts: new Date().toISOString(),
+    cat,
+    action,
+    label,
+    ...(detail ? { detail } : {}),
+  };
+  const events = await loadEvents();
+  events.unshift(event);
+  if (events.length > MAX_EVENTS) events.length = MAX_EVENTS;
+  await saveEvents(events);
+}
+
+export async function getActivity(limit = 50): Promise<ActivityEvent[]> {
+  const events = await loadEvents();
+  return events.slice(0, limit);
+}
+
+export async function setScanMeta(meta: ScanMeta): Promise<void> {
+  const r = getRedis();
+  if (r) {
+    await r.set(SCAN_META_KEY, meta);
+    return;
+  }
+  memScanMeta = meta;
+  fsPersist();
+}
+
+export async function getScanMeta(): Promise<ScanMeta | null> {
+  const r = getRedis();
+  if (r) return (await r.get<ScanMeta>(SCAN_META_KEY)) ?? null;
+  fsLoad();
+  return memScanMeta ? { ...memScanMeta } : null;
+}

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -1,0 +1,19 @@
+import "server-only";
+import { Redis } from "@upstash/redis";
+
+/* Shared Redis singleton for all server-side stores.
+ * Returns null when UPSTASH env vars are not set (local dev). */
+
+let instance: Redis | null = null;
+let checked = false;
+
+export function getRedis(): Redis | null {
+  if (checked) return instance;
+  checked = true;
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (url && token) {
+    instance = new Redis({ url, token });
+  }
+  return instance;
+}

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,7 +1,7 @@
 import "server-only";
-import { Redis } from "@upstash/redis";
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
 import { join } from "path";
+import { getRedis } from "./redis";
 import type { Alert, WatchlistStock } from "./types";
 
 /* ── Default watchlist (used on first run) ──────────────────────────── */
@@ -14,29 +14,8 @@ const DEFAULT_WATCHLIST: WatchlistStock[] = [
   { symbol: "RELIANCE", name: "Reliance Industries", closeWatch: false },
 ];
 
-/* ── Redis backend (Vercel / production) ────────────────────────────── *
- * When UPSTASH_REDIS_REST_URL + UPSTASH_REDIS_REST_TOKEN are set,
- * all state is stored in Upstash Redis so it persists across
- * serverless invocations.  On Vercel, enable the Upstash integration
- * and these env vars are injected automatically.
- * ──────────────────────────────────────────────────────────────────── */
-
 const WATCHLIST_KEY = "nse:watchlist";
 const ALERTS_KEY = "nse:alerts";
-
-let redisInstance: Redis | null = null;
-let redisChecked = false;
-
-function getRedis(): Redis | null {
-  if (redisChecked) return redisInstance;
-  redisChecked = true;
-  const url = process.env.UPSTASH_REDIS_REST_URL;
-  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
-  if (url && token) {
-    redisInstance = new Redis({ url, token });
-  }
-  return redisInstance;
-}
 
 /* ── Filesystem backend (local development) ─────────────────────────── *
  * Falls back to JSON file persistence when Redis is not configured.

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -68,3 +68,29 @@ export interface ScanResponse {
     date: string;
   };
 }
+
+/* ── Activity / Audit types ─────────────────────────────────────────── */
+
+export type ActivityCategory = "user" | "system" | "warning";
+
+export interface ActivityEvent {
+  id: string;
+  ts: string;
+  cat: ActivityCategory;
+  action: string;
+  label: string;
+  detail?: Record<string, unknown>;
+}
+
+export interface ScanMeta {
+  scannedAt: string;
+  scanType: "manual" | "auto";
+  marketOpen: boolean;
+  stockCount: number;
+  triggeredCount: number;
+  staleCount: number;
+  liveCount: number;
+  historicalCount: number;
+  closeWatchSymbols: string[];
+  alertsFired: string[];
+}


### PR DESCRIPTION
- Activity tracking system: persists user actions (stock add/remove, close-watch toggle, intraday/auto-check toggles) and system events (scans, alerts, stale data warnings) to Redis/filesystem
- Current State panel: at-a-glance market status, last scan, close-watch stocks, data health bar (live/historical/stale), alerts, cache stats
- Activity Timeline: filterable by category (user/system/warning), with distinct icons and color coding per action type
- Support Mode: hidden by default, enabled via ?support=true URL param or toggle button. Shows raw logs table and expandable event detail JSON
- Scan metadata persistence: every scan stores a ScanMeta snapshot so the dev dashboard can answer "what happened?" after restarts
- GSAP animations for state card entrances and new timeline entry reveals
- Shared Redis utility extracted to src/lib/redis.ts

https://claude.ai/code/session_015uWUM4qCNUUN6VFH5LMHsN