### PR TITLE
Dashboard: add status strip, Close Watch hero section, animations and alert polish

### DIFF
--- a/src/components/alert-panel.tsx
+++ b/src/components/alert-panel.tsx
@@ -11,7 +11,7 @@ export function AlertPanel({ alerts }: { alerts: Alert[] }) {
   if (recentAlerts.length === 0) return null;
 
   return (
-    <section className="mt-10">
+    <section className="mt-10 rounded-2xl border border-surface-border bg-surface-raised/60 p-4">
       <div className="mb-4 flex items-center gap-3">
         <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-accent/10">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="text-accent">
@@ -19,14 +19,15 @@ export function AlertPanel({ alerts }: { alerts: Alert[] }) {
           </svg>
         </div>
         <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">
-          Recent Breakout Alerts
+          Alert Receipts
         </h2>
+        <p className="text-[11px] text-text-muted">What triggered and when</p>
         <span className="rounded-full bg-accent/10 px-2 py-0.5 text-[10px] font-bold tabular-nums text-accent">
           {recentAlerts.length}
         </span>
         <div className="flex-1 border-t border-surface-border/40" />
       </div>
-      <div className="overflow-hidden rounded-2xl border border-surface-border bg-surface-raised">
+      <div className="overflow-hidden rounded-xl border border-surface-border/80 bg-surface-raised">
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead>

--- a/src/components/stock-card.tsx
+++ b/src/components/stock-card.tsx
@@ -105,7 +105,7 @@ export function StockCard({
           className={`flex h-7 w-7 items-center justify-center rounded-lg transition-all duration-200 ${
             closeWatch
               ? "text-amber-400 opacity-100 hover:bg-amber-400/15"
-              : "text-text-muted opacity-0 hover:bg-surface-overlay hover:text-amber-400 group-hover:opacity-100"
+              : "text-text-muted opacity-90 ring-1 ring-surface-border/60 hover:bg-surface-overlay hover:text-amber-400"
           }`}
           aria-label={`${closeWatch ? "Remove from" : "Add to"} close watch`}
           title={closeWatch ? "Remove from Close Watch" : "Add to Close Watch"}
@@ -122,7 +122,7 @@ export function StockCard({
         </button>
         <button
           onClick={() => onRemove(result.symbol)}
-          className="flex h-7 w-7 items-center justify-center rounded-lg text-text-muted opacity-0 transition-all duration-200 hover:bg-danger-muted hover:text-danger group-hover:opacity-100"
+          className="flex h-7 w-7 items-center justify-center rounded-lg text-text-muted opacity-70 transition-all duration-200 hover:bg-danger-muted hover:text-danger hover:opacity-100"
           aria-label={`Remove ${result.symbol}`}
         >
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
@@ -147,12 +147,12 @@ export function StockCard({
           <div>
             <div className="flex items-center gap-2">
               <h3 className="font-semibold tracking-tight">{result.symbol}</h3>
-              {closeWatch && !result.triggered && (
-                <span className="inline-flex items-center gap-0.5 rounded-md bg-amber-400/10 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-amber-400/80">
+              {closeWatch && (
+                <span className="inline-flex items-center gap-1 rounded-md border border-amber-400/25 bg-amber-400/10 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-amber-300">
                   <svg width="8" height="8" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="1">
                     <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
                   </svg>
-                  Watching
+                  Close Watch
                 </span>
               )}
               {result.triggered && (


### PR DESCRIPTION
### Motivation
- Make the dashboard feel like a calm trading cockpit with an at-a-glance status strip and clearer information hierarchy. 
- Ensure Close Watch is unmistakable and the star control is discoverable and responsive. 
- Improve feedback and motion so changes (star, list updates, live feed) are perceptible without being distracting.

### Description
- Added a compact status strip and UI primitives: `StatusStripPill`, `SectionTitle`, and `toStockResult` to `src/components/dashboard.tsx` and surfaced market/mode/auto-check/data-feed state. 
- Split the watchlist into a pinned "Close Watch" section (hero) and a secondary "All Watchlist Stocks" section, and moved alerts into a framed receipts-style panel for clearer context. 
- Introduced lightweight GSAP list motion on watchlist updates and a per-card entry animation to make star/unstar and reordering transitions easier to notice. 
- Improved Close Watch discoverability by keeping the star visible (no hover-only hide), adding a persistent `Close Watch` badge, and tweaking action button affordances; restyled the alerts panel for a receipt-like frame. (Files changed: `src/components/dashboard.tsx`, `src/components/stock-card.tsx`, `src/components/alert-panel.tsx`.)

### Testing
- Ran TypeScript checks with `npm run typecheck`; the typecheck completed successfully. 
- Attempted linting with `npm run lint`; the run could not complete non-interactively because Next.js prompted to initialize ESLint in this environment. 
- Launched the dev server and captured a full-page screenshot to validate visual layout and animations (artifact: `artifacts/dashboard-ui-improvements.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993c84915ac83258768488aeeb2d63d)