### PR TITLE
Add Nifty 50 Index display and enrich activity timeline with actor/ch…

### DIFF
--- a/src/app/api/activity/route.ts
+++ b/src/app/api/activity/route.ts
@@ -4,10 +4,19 @@ import { z } from "zod";
 
 export const dynamic = "force-dynamic";
 
+const changeSchema = z.object({
+  field: z.string(),
+  from: z.union([z.string(), z.number(), z.boolean()]).optional(),
+  to: z.union([z.string(), z.number(), z.boolean()]).optional(),
+});
+
 const postSchema = z.object({
   action: z.string().min(1).max(50),
   label: z.string().min(1).max(200),
   cat: z.enum(["user", "system", "warning"]).default("user"),
+  actor: z.enum(["dad", "system", "auto-check"]).optional(),
+  changes: z.array(changeSchema).optional(),
+  snapshot: z.record(z.unknown()).optional(),
   detail: z.record(z.unknown()).optional(),
 });
 
@@ -28,8 +37,8 @@ export async function POST(request: Request) {
         { status: 400 }
       );
     }
-    const { cat, action, label, detail } = parsed.data;
-    await addActivity(cat, action, label, detail);
+    const { cat, action, label, actor, changes, snapshot, detail } = parsed.data;
+    await addActivity(cat, action, label, { actor, changes, snapshot, detail });
     return NextResponse.json({ ok: true });
   } catch {
     return NextResponse.json({ error: "Invalid request" }, { status: 400 });

--- a/src/app/api/index/route.ts
+++ b/src/app/api/index/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import { getNifty50Index } from "@/lib/nse-client";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 15;
+
+export async function GET() {
+  try {
+    const nifty = await getNifty50Index();
+    if (!nifty) {
+      return NextResponse.json({ error: "Unavailable" }, { status: 503 });
+    }
+    return NextResponse.json(nifty);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Index fetch failed";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/state/route.ts
+++ b/src/app/api/state/route.ts
@@ -1,18 +1,19 @@
 import { NextResponse } from "next/server";
 import { getWatchlist, getAlerts } from "@/lib/store";
 import { getScanMeta } from "@/lib/activity";
-import { getMarketStatus, getHistoricalCacheStats } from "@/lib/nse-client";
+import { getMarketStatus, getHistoricalCacheStats, getNifty50Index } from "@/lib/nse-client";
 
 export const dynamic = "force-dynamic";
 
 export async function GET() {
-  const [watchlist, alerts, scanMeta, marketOpen, cacheStats] =
+  const [watchlist, alerts, scanMeta, marketOpen, cacheStats, nifty] =
     await Promise.all([
       getWatchlist(),
       getAlerts(),
       getScanMeta(),
       getMarketStatus().catch(() => false),
       Promise.resolve(getHistoricalCacheStats()),
+      getNifty50Index().catch(() => null),
     ]);
 
   const closeWatchStocks = watchlist.filter((s) => s.closeWatch);
@@ -31,6 +32,7 @@ export async function GET() {
     },
     scan: scanMeta,
     cache: cacheStats,
+    nifty: nifty ?? null,
     serverTime: new Date().toISOString(),
   });
 }

--- a/src/app/api/stocks/route.ts
+++ b/src/app/api/stocks/route.ts
@@ -76,7 +76,11 @@ export async function POST(request: Request) {
         'Watchlist',
         `"${parsed.data.name}" has been added to your watchlist. It will now be included in every scan cycle.`,
       );
-      await addActivity("user", "stock-added", `Added ${parsed.data.symbol} to watchlist`, { symbol: parsed.data.symbol, name: parsed.data.name });
+      await addActivity("user", "stock-added", `Added ${parsed.data.symbol} to watchlist`, {
+        actor: "dad",
+        changes: [{ field: "watchlist", to: parsed.data.symbol }],
+        detail: { symbol: parsed.data.symbol, name: parsed.data.name },
+      });
       return NextResponse.json({ watchlist });
     }
 
@@ -95,7 +99,11 @@ export async function POST(request: Request) {
         'Watchlist',
         `"${parsed.data.symbol}" has been removed from your watchlist. It will no longer be scanned.`,
       );
-      await addActivity("user", "stock-removed", `Removed ${parsed.data.symbol} from watchlist`, { symbol: parsed.data.symbol });
+      await addActivity("user", "stock-removed", `Removed ${parsed.data.symbol} from watchlist`, {
+        actor: "dad",
+        changes: [{ field: "watchlist", from: parsed.data.symbol }],
+        detail: { symbol: parsed.data.symbol },
+      });
       return NextResponse.json({ watchlist });
     }
 
@@ -119,7 +127,11 @@ export async function POST(request: Request) {
         "user",
         isNowWatching ? "closewatch-on" : "closewatch-off",
         `${isNowWatching ? "Starred" : "Unstarred"} ${parsed.data.symbol} for close watch`,
-        { symbol: parsed.data.symbol, closeWatch: isNowWatching }
+        {
+          actor: "dad",
+          changes: [{ field: "closeWatch", from: !isNowWatching, to: isNowWatching }],
+          detail: { symbol: parsed.data.symbol, closeWatch: isNowWatching },
+        }
       );
       return NextResponse.json({ watchlist });
     }

--- a/src/app/api/ticker/route.ts
+++ b/src/app/api/ticker/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { getCloseWatchStocks } from "@/lib/store";
-import { getCurrentDayData } from "@/lib/nse-client";
+import { getCurrentDayData, getNifty50Index } from "@/lib/nse-client";
 import { logger } from "@/lib/logger";
 import type { TickerQuote } from "@/lib/types";
 
@@ -49,8 +49,12 @@ export async function GET() {
       `Successfully fetched live prices for ${quotes.length} out of ${stocks.length} Close Watch stock(s). ${quotes.length < stocks.length ? `${stocks.length - quotes.length} stock(s) couldn't be fetched — they may be newly listed or the NSE may be temporarily unavailable for those symbols.` : 'All prices are up to date.'}`,
     );
 
+    // Fetch Nifty 50 index in parallel (best-effort)
+    const nifty = await getNifty50Index().catch(() => null);
+
     return NextResponse.json({
       quotes,
+      nifty,
       fetchedAt: new Date().toISOString(),
     });
   } catch (error) {

--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -310,7 +310,8 @@ export function Dashboard({
                   setAutoCheckActive(next);
                   reportAction(
                     next ? "autocheck-started" : "autocheck-stopped",
-                    next ? "Started auto-check (30s interval)" : "Stopped auto-check"
+                    next ? "Started auto-check (30s interval)" : "Stopped auto-check",
+                    { changes: [{ field: "autoCheck", from: !next, to: next }] }
                   );
                 }}
                 className={`flex items-center gap-1.5 rounded-lg border px-3.5 py-2.5 text-xs font-medium transition-all duration-200 ${
@@ -351,7 +352,8 @@ export function Dashboard({
                 setIntraday(next);
                 reportAction(
                   next ? "intraday-on" : "intraday-off",
-                  next ? "Switched to intraday mode" : "Switched to historical mode"
+                  next ? "Switched to intraday mode" : "Switched to historical mode",
+                  { changes: [{ field: "intraday", from: !next, to: next }] }
                 );
               }}
             />
@@ -470,11 +472,11 @@ function StatCard({
 }
 
 /* Fire-and-forget activity reporter for client-side user actions */
-function reportAction(action: string, label: string, detail?: Record<string, unknown>) {
+function reportAction(action: string, label: string, opts?: { detail?: Record<string, unknown>; changes?: { field: string; from?: string | number | boolean; to?: string | number | boolean }[] }) {
   fetch("/api/activity", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ cat: "user", action, label, detail }),
+    body: JSON.stringify({ cat: "user", action, label, actor: "dad", ...opts }),
   }).catch(() => {});
 }
 

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,7 +1,8 @@
 "use client";
 
+import { useState, useEffect, useCallback, useRef } from "react";
 import { NotificationBell } from "./notification-bell";
-import type { Alert } from "@/lib/types";
+import type { Alert, NiftyIndex } from "@/lib/types";
 
 export function Header({
   alerts,
@@ -14,6 +15,34 @@ export function Header({
   onMarkRead: (id: string) => void;
   marketOpen: boolean;
 }) {
+  const [nifty, setNifty] = useState<NiftyIndex | null>(null);
+  const prevValueRef = useRef<number | null>(null);
+  const [flash, setFlash] = useState<"up" | "down" | null>(null);
+
+  const fetchIndex = useCallback(async () => {
+    try {
+      const res = await fetch("/api/index");
+      if (!res.ok) return;
+      const data: NiftyIndex = await res.json();
+      if (data.value) {
+        if (prevValueRef.current !== null && prevValueRef.current !== data.value) {
+          setFlash(data.value > prevValueRef.current ? "up" : "down");
+          setTimeout(() => setFlash(null), 1200);
+        }
+        prevValueRef.current = data.value;
+        setNifty(data);
+      }
+    } catch { /* silent */ }
+  }, []);
+
+  useEffect(() => {
+    fetchIndex();
+    const interval = setInterval(fetchIndex, 15_000);
+    return () => clearInterval(interval);
+  }, [fetchIndex]);
+
+  const isUp = nifty ? nifty.change >= 0 : true;
+
   return (
     <header className="sticky top-0 z-30 border-b border-surface-border/60 glass">
       <div className="absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-accent/20 to-transparent" />
@@ -44,7 +73,43 @@ export function Header({
           </div>
         </div>
 
-        <div className="flex items-center gap-5">
+        <div className="flex items-center gap-3">
+          {/* Nifty 50 Index */}
+          {nifty && (
+            <div
+              className={`flex items-center gap-2.5 rounded-lg border px-3 py-1.5 transition-all duration-300 ${
+                flash === "up"
+                  ? "border-accent/40 bg-accent/[0.08]"
+                  : flash === "down"
+                    ? "border-danger/40 bg-danger/[0.08]"
+                    : "border-surface-border/60 bg-surface-overlay/40"
+              }`}
+              title={`Open: ${nifty.open.toLocaleString("en-IN")} · High: ${nifty.high.toLocaleString("en-IN")} · Low: ${nifty.low.toLocaleString("en-IN")} · Prev Close: ${nifty.previousClose.toLocaleString("en-IN")}`}
+            >
+              <div className="flex items-center gap-1.5">
+                <span className="text-[10px] font-bold uppercase tracking-wider text-text-muted">
+                  Nifty 50
+                </span>
+                <span className="text-sm font-bold tabular-nums tracking-tight text-text-primary">
+                  {nifty.value.toLocaleString("en-IN", { maximumFractionDigits: 2 })}
+                </span>
+              </div>
+              <div className={`flex items-center gap-1 ${isUp ? "text-accent" : "text-danger"}`}>
+                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5"
+                  className={isUp ? "" : "rotate-180"}>
+                  <polyline points="18 15 12 9 6 15" />
+                </svg>
+                <span className="text-xs font-semibold tabular-nums">
+                  {nifty.change >= 0 ? "+" : ""}{nifty.change.toFixed(2)}
+                </span>
+                <span className="text-[10px] font-medium tabular-nums opacity-70">
+                  ({nifty.changePercent >= 0 ? "+" : ""}{nifty.changePercent.toFixed(2)}%)
+                </span>
+              </div>
+            </div>
+          )}
+
+          {/* Market Status */}
           <div className="flex items-center gap-2.5 rounded-lg border border-surface-border/60 bg-surface-overlay/40 px-3 py-1.5">
             <span className="relative flex h-2 w-2">
               <span

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -2,7 +2,7 @@ import "server-only";
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
 import { join } from "path";
 import { getRedis } from "./redis";
-import type { ActivityEvent, ActivityCategory, ScanMeta } from "./types";
+import type { ActivityEvent, ActivityCategory, ActivityActor, ActivityChange, ScanMeta } from "./types";
 
 /* ── Keys & limits ──────────────────────────────────────────────────── */
 
@@ -84,7 +84,12 @@ export async function addActivity(
   cat: ActivityCategory,
   action: string,
   label: string,
-  detail?: Record<string, unknown>
+  opts?: {
+    detail?: Record<string, unknown>;
+    actor?: ActivityActor;
+    changes?: ActivityChange[];
+    snapshot?: Record<string, unknown>;
+  }
 ): Promise<void> {
   const event: ActivityEvent = {
     id: `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
@@ -92,7 +97,10 @@ export async function addActivity(
     cat,
     action,
     label,
-    ...(detail ? { detail } : {}),
+    ...(opts?.actor ? { actor: opts.actor } : {}),
+    ...(opts?.changes?.length ? { changes: opts.changes } : {}),
+    ...(opts?.snapshot ? { snapshot: opts.snapshot } : {}),
+    ...(opts?.detail ? { detail: opts.detail } : {}),
   };
   const events = await loadEvents();
   events.unshift(event);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -69,9 +69,30 @@ export interface ScanResponse {
   };
 }
 
+/* ── Nifty 50 Index ────────────────────────────────────────────────── */
+
+export interface NiftyIndex {
+  value: number;
+  change: number;
+  changePercent: number;
+  open: number;
+  high: number;
+  low: number;
+  previousClose: number;
+  fetchedAt: string;
+}
+
 /* ── Activity / Audit types ─────────────────────────────────────────── */
 
 export type ActivityCategory = "user" | "system" | "warning";
+
+export type ActivityActor = "dad" | "system" | "auto-check";
+
+export interface ActivityChange {
+  field: string;
+  from?: string | number | boolean;
+  to?: string | number | boolean;
+}
 
 export interface ActivityEvent {
   id: string;
@@ -79,6 +100,9 @@ export interface ActivityEvent {
   cat: ActivityCategory;
   action: string;
   label: string;
+  actor?: ActivityActor;
+  changes?: ActivityChange[];
+  snapshot?: Record<string, unknown>;
   detail?: Record<string, unknown>;
 }
 


### PR DESCRIPTION
…ange tracking

- Nifty 50 Index: new getNifty50Index() in nse-client with 15s cache, /api/index endpoint, live badge in header with flash-on-change, and index card in dev dashboard state panel
- Activity audit trail: events now carry actor (dad/system/auto-check), changes (field/from/to diffs), and snapshot (what the system saw)
- Dev dashboard: actor badges, inline change pills, expandable "System saw" snapshot panel per timeline entry
- All emitters updated: scan, stocks, and client-side actions now include who triggered it and what changed

https://claude.ai/code/session_015uWUM4qCNUUN6VFH5LMHsN