### PR TITLE
Auto-start live ticker when a stock is starred for Close Watch

### DIFF
--- a/src/components/ticker-panel.tsx
+++ b/src/components/ticker-panel.tsx
@@ -74,9 +74,11 @@ export function TickerPanel({
     };
   }, [active, hasCloseWatchStocks, fetchTicker]);
 
-  // Reset when no close-watch stocks
+  // Auto-start when close-watch stocks appear, reset when they disappear
   useEffect(() => {
-    if (!hasCloseWatchStocks) {
+    if (hasCloseWatchStocks) {
+      setActive(true);
+    } else {
       setActive(false);
       setQuotes([]);
     }


### PR DESCRIPTION
Previously the ticker defaulted to inactive and required pressing "Start" even after starring a stock. Now it auto-activates whenever close-watch stocks exist and still pauses when all stars are removed.

https://claude.ai/code/session_015uWUM4qCNUUN6VFH5LMHsN