### PR TITLE
Eliminate unnecessary NSE API calls after market hours

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -42,16 +42,18 @@ export function Header({
   }, []);
 
   useEffect(() => {
-    // Always fetch once on mount to show last-known value
+    // Fetch once on mount — the server-side cache in nse-client will
+    // return the last-known closing value without hitting NSE after hours.
     fetchIndex();
 
+    // Only set up a polling interval during extended hours
+    if (!isExtendedHours()) return;
+
     const interval = setInterval(() => {
-      const live = isExtendedHours();
-      if (live) {
+      if (isExtendedHours()) {
         fetchIndex();
       }
-      // After hours: don't poll (we already have the closing value)
-    }, isExtendedHours() ? NIFTY_POLL_LIVE : NIFTY_POLL_CLOSED);
+    }, NIFTY_POLL_LIVE);
 
     return () => clearInterval(interval);
   }, [fetchIndex]);


### PR DESCRIPTION
getMarketStatus(): outside extended hours (before 09:00 / after 16:00 IST), returns false immediately without hitting NSE. During extended hours, caches the result for 60s so the dev panel's 5s auto-refresh doesn't hammer the API.

getNifty50Index(): outside extended hours, returns cached closing value without hitting NSE. Only makes one seeding call if no cache exists.

Header: no polling interval after hours at all — just one fetch on mount (which resolves from server-side cache, not NSE).

https://claude.ai/code/session_015uWUM4qCNUUN6VFH5LMHsN