### PR TITLE
Add low-break alert: trigger when LTP falls below 10-day lowest low

### DIFF
--- a/src/components/alert-panel.tsx
+++ b/src/components/alert-panel.tsx
@@ -10,97 +10,190 @@ export function AlertPanel({ alerts }: { alerts: Alert[] }) {
 
   if (recentAlerts.length === 0) return null;
 
+  const breakoutAlerts = recentAlerts.filter((a) => (a.alertType ?? "breakout") === "breakout");
+  const lowBreakAlerts = recentAlerts.filter((a) => a.alertType === "low-break");
+
   return (
-    <section className="mt-10">
-      <div className="mb-4 flex items-center gap-3">
-        <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-accent/10">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="text-accent">
-            <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" />
-          </svg>
+    <section className="mt-10 space-y-8">
+      {/* ── Breakout Alerts ───────────────────────────────────────────── */}
+      {breakoutAlerts.length > 0 && (
+        <div>
+          <div className="mb-4 flex items-center gap-3">
+            <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-accent/10">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="text-accent">
+                <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" />
+              </svg>
+            </div>
+            <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">
+              Breakout Alerts
+            </h2>
+            <span className="rounded-full bg-accent/10 px-2 py-0.5 text-[10px] font-bold tabular-nums text-accent">
+              {breakoutAlerts.length}
+            </span>
+            <div className="flex-1 border-t border-surface-border/40" />
+          </div>
+          <div className="overflow-hidden rounded-2xl border border-surface-border bg-surface-raised">
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-surface-border bg-surface-overlay/30 text-left text-xs text-text-muted">
+                    <th className="px-5 py-3.5 font-medium">Stock</th>
+                    <th className="px-4 py-3.5 font-medium text-right">Today High</th>
+                    <th className="px-4 py-3.5 font-medium text-right">5d Max High</th>
+                    <th className="px-4 py-3.5 font-medium text-right">High Break</th>
+                    <th className="px-4 py-3.5 font-medium text-right">Today Vol</th>
+                    <th className="px-4 py-3.5 font-medium text-right">5d Max Vol</th>
+                    <th className="px-4 py-3.5 font-medium text-right">Vol Break</th>
+                    <th className="px-4 py-3.5 font-medium text-right">Time</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {breakoutAlerts.map((alert, i) => (
+                    <tr
+                      key={alert.id}
+                      className="animate-fade-in border-b border-surface-border/30 transition-colors duration-200 hover:bg-surface-overlay/20"
+                      style={{ animationDelay: `${i * 50}ms` }}
+                    >
+                      <td className="px-5 py-3.5">
+                        <div className="flex items-center gap-2.5">
+                          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-accent/10 text-[10px] font-bold text-accent">
+                            {alert.symbol.slice(0, 2)}
+                          </div>
+                          <div>
+                            <div className="font-semibold">{alert.symbol}</div>
+                            <div className="text-[11px] text-text-muted">{alert.name}</div>
+                          </div>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3.5 text-right font-medium tabular-nums text-accent">
+                        &#x20B9;{alert.todayHigh.toLocaleString("en-IN")}
+                      </td>
+                      <td className="px-4 py-3.5 text-right tabular-nums text-text-secondary">
+                        &#x20B9;{alert.prevMaxHigh.toLocaleString("en-IN")}
+                      </td>
+                      <td className="px-4 py-3.5 text-right">
+                        <span className="inline-flex items-center gap-1 rounded-md bg-accent/10 px-2 py-0.5 text-xs font-bold tabular-nums text-accent">
+                          <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3">
+                            <polyline points="18 15 12 9 6 15" />
+                          </svg>
+                          {alert.highBreakPercent.toFixed(1)}%
+                        </span>
+                      </td>
+                      <td className="px-4 py-3.5 text-right font-medium tabular-nums text-accent">
+                        {formatVolume(alert.todayVolume)}
+                      </td>
+                      <td className="px-4 py-3.5 text-right tabular-nums text-text-secondary">
+                        {formatVolume(alert.prevMaxVolume)}
+                      </td>
+                      <td className="px-4 py-3.5 text-right">
+                        <span className="inline-flex items-center gap-1 rounded-md bg-accent/10 px-2 py-0.5 text-xs font-bold tabular-nums text-accent">
+                          <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3">
+                            <polyline points="18 15 12 9 6 15" />
+                          </svg>
+                          {alert.volumeBreakPercent.toFixed(1)}%
+                        </span>
+                      </td>
+                      <td className="px-4 py-3.5 text-right text-xs text-text-muted">
+                        {new Date(alert.triggeredAt).toLocaleString("en-IN", {
+                          day: "2-digit",
+                          month: "short",
+                          hour: "2-digit",
+                          minute: "2-digit",
+                        })}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
         </div>
-        <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">
-          Recent Breakout Alerts
-        </h2>
-        <span className="rounded-full bg-accent/10 px-2 py-0.5 text-[10px] font-bold tabular-nums text-accent">
-          {recentAlerts.length}
-        </span>
-        <div className="flex-1 border-t border-surface-border/40" />
-      </div>
-      <div className="overflow-hidden rounded-2xl border border-surface-border bg-surface-raised">
-        <div className="overflow-x-auto">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-surface-border bg-surface-overlay/30 text-left text-xs text-text-muted">
-                <th className="px-5 py-3.5 font-medium">Stock</th>
-                <th className="px-4 py-3.5 font-medium text-right">Today High</th>
-                <th className="px-4 py-3.5 font-medium text-right">5d Max High</th>
-                <th className="px-4 py-3.5 font-medium text-right">High Break</th>
-                <th className="px-4 py-3.5 font-medium text-right">Today Vol</th>
-                <th className="px-4 py-3.5 font-medium text-right">5d Max Vol</th>
-                <th className="px-4 py-3.5 font-medium text-right">Vol Break</th>
-                <th className="px-4 py-3.5 font-medium text-right">Time</th>
-              </tr>
-            </thead>
-            <tbody>
-              {recentAlerts.map((alert, i) => (
-                <tr
-                  key={alert.id}
-                  className="animate-fade-in border-b border-surface-border/30 transition-colors duration-200 hover:bg-surface-overlay/20"
-                  style={{ animationDelay: `${i * 50}ms` }}
-                >
-                  <td className="px-5 py-3.5">
-                    <div className="flex items-center gap-2.5">
-                      <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-accent/10 text-[10px] font-bold text-accent">
-                        {alert.symbol.slice(0, 2)}
-                      </div>
-                      <div>
-                        <div className="font-semibold">{alert.symbol}</div>
-                        <div className="text-[11px] text-text-muted">{alert.name}</div>
-                      </div>
-                    </div>
-                  </td>
-                  <td className="px-4 py-3.5 text-right font-medium tabular-nums text-accent">
-                    &#x20B9;{alert.todayHigh.toLocaleString("en-IN")}
-                  </td>
-                  <td className="px-4 py-3.5 text-right tabular-nums text-text-secondary">
-                    &#x20B9;{alert.prevMaxHigh.toLocaleString("en-IN")}
-                  </td>
-                  <td className="px-4 py-3.5 text-right">
-                    <span className="inline-flex items-center gap-1 rounded-md bg-accent/10 px-2 py-0.5 text-xs font-bold tabular-nums text-accent">
-                      <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3">
-                        <polyline points="18 15 12 9 6 15" />
-                      </svg>
-                      {alert.highBreakPercent.toFixed(1)}%
-                    </span>
-                  </td>
-                  <td className="px-4 py-3.5 text-right font-medium tabular-nums text-accent">
-                    {formatVolume(alert.todayVolume)}
-                  </td>
-                  <td className="px-4 py-3.5 text-right tabular-nums text-text-secondary">
-                    {formatVolume(alert.prevMaxVolume)}
-                  </td>
-                  <td className="px-4 py-3.5 text-right">
-                    <span className="inline-flex items-center gap-1 rounded-md bg-accent/10 px-2 py-0.5 text-xs font-bold tabular-nums text-accent">
-                      <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3">
-                        <polyline points="18 15 12 9 6 15" />
-                      </svg>
-                      {alert.volumeBreakPercent.toFixed(1)}%
-                    </span>
-                  </td>
-                  <td className="px-4 py-3.5 text-right text-xs text-text-muted">
-                    {new Date(alert.triggeredAt).toLocaleString("en-IN", {
-                      day: "2-digit",
-                      month: "short",
-                      hour: "2-digit",
-                      minute: "2-digit",
-                    })}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+      )}
+
+      {/* ── Low-Break Alerts ──────────────────────────────────────────── */}
+      {lowBreakAlerts.length > 0 && (
+        <div>
+          <div className="mb-4 flex items-center gap-3">
+            <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-red-500/10">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="text-red-400">
+                <polyline points="22 17 13.5 8.5 8.5 13.5 2 7" />
+                <polyline points="16 17 22 17 22 11" />
+              </svg>
+            </div>
+            <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">
+              Low-Break Alerts
+            </h2>
+            <span className="rounded-full bg-red-500/10 px-2 py-0.5 text-[10px] font-bold tabular-nums text-red-400">
+              {lowBreakAlerts.length}
+            </span>
+            <div className="flex-1 border-t border-surface-border/40" />
+          </div>
+          <div className="overflow-hidden rounded-2xl border border-red-500/15 bg-surface-raised">
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-surface-border bg-surface-overlay/30 text-left text-xs text-text-muted">
+                    <th className="px-5 py-3.5 font-medium">Stock</th>
+                    <th className="px-4 py-3.5 font-medium text-right">LTP</th>
+                    <th className="px-4 py-3.5 font-medium text-right">10d Low</th>
+                    <th className="px-4 py-3.5 font-medium text-right">Break %</th>
+                    <th className="px-4 py-3.5 font-medium text-right">Day Change</th>
+                    <th className="px-4 py-3.5 font-medium text-right">Time</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {lowBreakAlerts.map((alert, i) => (
+                    <tr
+                      key={alert.id}
+                      className="animate-fade-in border-b border-surface-border/30 transition-colors duration-200 hover:bg-red-500/[0.03]"
+                      style={{ animationDelay: `${i * 50}ms` }}
+                    >
+                      <td className="px-5 py-3.5">
+                        <div className="flex items-center gap-2.5">
+                          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-red-500/10 text-[10px] font-bold text-red-400">
+                            {alert.symbol.slice(0, 2)}
+                          </div>
+                          <div>
+                            <div className="font-semibold">{alert.symbol}</div>
+                            <div className="text-[11px] text-text-muted">{alert.name}</div>
+                          </div>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3.5 text-right font-medium tabular-nums text-red-400">
+                        &#x20B9;{alert.todayClose.toLocaleString("en-IN")}
+                      </td>
+                      <td className="px-4 py-3.5 text-right tabular-nums text-text-secondary">
+                        &#x20B9;{alert.prev10DayLow.toLocaleString("en-IN")}
+                      </td>
+                      <td className="px-4 py-3.5 text-right">
+                        <span className="inline-flex items-center gap-1 rounded-md bg-red-500/10 px-2 py-0.5 text-xs font-bold tabular-nums text-red-400">
+                          <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3">
+                            <polyline points="6 9 12 15 18 9" />
+                          </svg>
+                          -{alert.lowBreakPercent.toFixed(1)}%
+                        </span>
+                      </td>
+                      <td className="px-4 py-3.5 text-right">
+                        <span className={`text-xs font-semibold tabular-nums ${alert.todayChange >= 0 ? "text-accent" : "text-red-400"}`}>
+                          {alert.todayChange >= 0 ? "+" : ""}{alert.todayChange.toFixed(2)}%
+                        </span>
+                      </td>
+                      <td className="px-4 py-3.5 text-right text-xs text-text-muted">
+                        {new Date(alert.triggeredAt).toLocaleString("en-IN", {
+                          day: "2-digit",
+                          month: "short",
+                          hour: "2-digit",
+                          minute: "2-digit",
+                        })}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
         </div>
-      </div>
+      )}
     </section>
   );
 }

--- a/src/components/stock-card.tsx
+++ b/src/components/stock-card.tsx
@@ -25,6 +25,7 @@ export function StockCard({
   const isLive = result.dataSource === "live";
   const highBreaks = hasData && !isStale && result.todayHigh > result.prevMaxHigh;
   const volBreaks = hasData && !isStale && result.todayVolume > result.prevMaxVolume;
+  const lowBreaks = hasData && !isStale && result.lowBreakTriggered;
 
   // Animate star toggle transitions
   useEffect(() => {
@@ -73,19 +74,24 @@ export function StockCard({
           ? "border-warn/30 bg-surface-raised"
           : result.triggered
             ? "border-accent/30 card-glow bg-surface-raised"
-            : closeWatch
-              ? "border-amber-400/25 bg-surface-raised hover:shadow-xl hover:shadow-amber-400/5"
-              : "border-surface-border bg-surface-raised hover:border-surface-border/80 hover:shadow-xl hover:shadow-black/20"
+            : lowBreaks
+              ? "border-red-500/30 bg-surface-raised"
+              : closeWatch
+                ? "border-amber-400/25 bg-surface-raised hover:shadow-xl hover:shadow-amber-400/5"
+                : "border-surface-border bg-surface-raised hover:border-surface-border/80 hover:shadow-xl hover:shadow-black/20"
       }`}
     >
       {/* Top edge highlight */}
       {result.triggered && !isStale && (
         <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-accent/60 to-transparent" />
       )}
+      {lowBreaks && !result.triggered && (
+        <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-red-500/60 to-transparent" />
+      )}
       {isStale && (
         <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-warn/60 to-transparent" />
       )}
-      {closeWatch && !result.triggered && !isStale && (
+      {closeWatch && !result.triggered && !lowBreaks && !isStale && (
         <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-amber-400/50 to-transparent" />
       )}
 
@@ -159,6 +165,12 @@ export function StockCard({
                 <span className="inline-flex items-center gap-1 rounded-md bg-accent/15 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-accent">
                   <span className="h-1 w-1 rounded-full bg-accent animate-pulse" />
                   Breakout
+                </span>
+              )}
+              {lowBreaks && (
+                <span className="inline-flex items-center gap-1 rounded-md bg-red-500/15 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-red-400">
+                  <span className="h-1 w-1 rounded-full bg-red-400 animate-pulse" />
+                  Low Break
                 </span>
               )}
               {isLive && (
@@ -240,6 +252,7 @@ export function StockCard({
         <div className="mt-4 flex gap-2">
           <StatusPill active={highBreaks} label="High Break" />
           <StatusPill active={volBreaks} label="Vol Break" />
+          <StatusPill active={lowBreaks} label="Low Break" variant={lowBreaks ? "danger" : undefined} />
         </div>
       )}
 
@@ -315,17 +328,28 @@ function MetricBar({
   );
 }
 
-function StatusPill({ active, label }: { active: boolean; label: string }) {
+function StatusPill({ active, label, variant }: { active: boolean; label: string; variant?: "danger" }) {
+  const isDanger = variant === "danger";
   return (
     <span
       className={`inline-flex items-center gap-1 rounded-lg px-2.5 py-1 text-[11px] font-medium transition-colors ${
-        active ? "bg-accent/10 text-accent" : "bg-surface-overlay text-text-muted"
+        active
+          ? isDanger
+            ? "bg-red-500/10 text-red-400"
+            : "bg-accent/10 text-accent"
+          : "bg-surface-overlay text-text-muted"
       }`}
     >
       {active ? (
-        <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3">
-          <polyline points="20 6 9 17 4 12" />
-        </svg>
+        isDanger ? (
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3">
+            <polyline points="6 9 12 15 18 9" />
+          </svg>
+        ) : (
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3">
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
+        )
       ) : (
         <span className="text-[8px]">&mdash;</span>
       )}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -29,12 +29,18 @@ export interface ScanResult {
   todayChange: number;
   scannedAt: string;
   dataSource: DataSource;
+  lowBreakTriggered: boolean;
+  prev10DayLow: number;
+  lowBreakPercent: number;
 }
+
+export type AlertType = "breakout" | "low-break";
 
 export interface Alert {
   id: string;
   symbol: string;
   name: string;
+  alertType: AlertType;
   todayHigh: number;
   todayVolume: number;
   prevMaxHigh: number;
@@ -43,6 +49,8 @@ export interface Alert {
   volumeBreakPercent: number;
   todayClose: number;
   todayChange: number;
+  prev10DayLow: number;
+  lowBreakPercent: number;
   triggeredAt: string;
   read: boolean;
 }


### PR DESCRIPTION
New alert condition fires when the real-time last traded price drops below the minimum daily low of the previous 10 completed trading days. Volume is not considered for this signal.

Changes:
- types.ts: Add alertType discriminator, lowBreakTriggered, prev10DayLow, lowBreakPercent fields to ScanResult and Alert
- scanner.ts: Analyze 10-day low alongside existing 5-day breakout; fetch 25 calendar days of history for sufficient trading day coverage
- scan/route.ts: Generate low-break alerts with separate dedup IDs
- alert-panel.tsx: Split into Breakout Alerts and Low-Break Alerts tables with distinct red/bearish styling for low-break
- stock-card.tsx: Show "Low Break" badge, red border highlight, and danger-variant status pill when LTP < 10-day low
- dashboard.tsx: Separate dedup tracking for breakout vs low-break, browser notifications for low-break signals with 5-min cooldown

https://claude.ai/code/session_015uWUM4qCNUUN6VFH5LMHsN