### PR TITLE
Merge Pull request 24

### DIFF
--- a/src/app/api/candles/route.ts
+++ b/src/app/api/candles/route.ts
@@ -1,0 +1,83 @@
+import { NextResponse } from "next/server";
+import { getHistoricalData } from "@/lib/nse-client";
+import { logger } from "@/lib/logger";
+
+/**
+ * GET /api/candles?symbol=INFY&days=25
+ *
+ * Returns historical daily OHLCV candles for a symbol.
+ * Served via Vercel CDN with aggressive caching — historical candle
+ * data for completed trading days doesn't change within a calendar day.
+ *
+ * Cache strategy:
+ *   CDN-Cache-Control: s-maxage=3600 (fresh 1 h) + stale-while-revalidate=43200 (12 h)
+ *   Cache-Control:     max-age=60 (browser caches 1 min only)
+ *
+ * The Vercel CDN cache is best-effort; callers should handle cache misses
+ * gracefully (the function will re-execute and return fresh data).
+ */
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const symbol = searchParams.get("symbol")?.toUpperCase().trim();
+  const days = parseInt(searchParams.get("days") || "25", 10);
+
+  if (!symbol) {
+    return NextResponse.json(
+      { error: "Missing required query parameter: symbol", example: "/api/candles?symbol=INFY&days=25" },
+      { status: 400 }
+    );
+  }
+
+  if (isNaN(days) || days < 1 || days > 365) {
+    return NextResponse.json(
+      { error: "days must be between 1 and 365", received: searchParams.get("days") },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const start = Date.now();
+    const candles = await getHistoricalData(symbol, days);
+    const durationMs = Date.now() - start;
+
+    logger.debug(
+      `Candles served: ${symbol} (${candles.length} days, ${durationMs}ms)`,
+      { symbol, days, candleCount: candles.length, durationMs },
+      "Candles API",
+    );
+
+    const response = NextResponse.json({
+      symbol,
+      days,
+      candles,
+      candleCount: candles.length,
+      fetchedAt: new Date().toISOString(),
+    });
+
+    // CDN caching: fresh for 1 hour, stale served for up to 12 hours
+    // while the CDN revalidates in the background.
+    // Vercel strips s-maxage / stale-while-revalidate from the browser
+    // response automatically when CDN-Cache-Control is set.
+    response.headers.set(
+      "CDN-Cache-Control",
+      "public, s-maxage=3600, stale-while-revalidate=43200"
+    );
+    // Short browser TTL so clients see relatively fresh data on refresh
+    response.headers.set("Cache-Control", "public, max-age=60");
+
+    return response;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.error(
+      `Candles API failed: ${symbol} — ${message}`,
+      { symbol, days, error: message },
+      "Candles API",
+      `Could not retrieve historical candle data for ${symbol}. This is typically caused by an NSE API timeout or the symbol not being found.`,
+    );
+
+    return NextResponse.json(
+      { error: "Failed to fetch candle data", symbol, detail: message },
+      { status: 502 }
+    );
+  }
+}

--- a/src/app/api/state/route.ts
+++ b/src/app/api/state/route.ts
@@ -1,15 +1,16 @@
 import { NextResponse } from "next/server";
-import { getWatchlist, getAlerts } from "@/lib/store";
+import { getWatchlist, getAlerts, getAllAlerts, clearAlerts } from "@/lib/store";
 import { getScanMeta } from "@/lib/activity";
 import { getMarketStatus, getHistoricalCacheStats, getNifty50Index, getApiStats } from "@/lib/nse-client";
 
 export const dynamic = "force-dynamic";
 
 export async function GET() {
-  const [watchlist, alerts, scanMeta, marketOpen, cacheStats, nifty] =
+  const [watchlist, todayAlerts, allAlerts, scanMeta, marketOpen, cacheStats, nifty] =
     await Promise.all([
       getWatchlist(),
       getAlerts(),
+      getAllAlerts(),
       getScanMeta(),
       getMarketStatus().catch(() => false),
       Promise.resolve(getHistoricalCacheStats()),
@@ -17,7 +18,14 @@ export async function GET() {
     ]);
 
   const closeWatchStocks = watchlist.filter((s) => s.closeWatch);
-  const unreadAlerts = alerts.filter((a) => !a.read).length;
+  const unreadAlerts = todayAlerts.filter((a) => !a.read).length;
+
+  // Group historical alerts by date for the dev panel
+  const alertsByDate: Record<string, number> = {};
+  for (const a of allAlerts) {
+    const date = a.triggeredAt.slice(0, 10);
+    alertsByDate[date] = (alertsByDate[date] || 0) + 1;
+  }
 
   return NextResponse.json({
     market: { open: marketOpen },
@@ -27,8 +35,10 @@ export async function GET() {
       closeWatchSymbols: closeWatchStocks.map((s) => s.symbol),
     },
     alerts: {
-      total: alerts.length,
+      today: todayAlerts.length,
       unread: unreadAlerts,
+      totalStored: allAlerts.length,
+      byDate: alertsByDate,
     },
     scan: scanMeta,
     cache: cacheStats,
@@ -36,4 +46,9 @@ export async function GET() {
     apiStats: getApiStats(),
     serverTime: new Date().toISOString(),
   });
+}
+
+export async function DELETE() {
+  await clearAlerts();
+  return NextResponse.json({ ok: true, cleared: true });
 }

--- a/src/app/dev/page.tsx
+++ b/src/app/dev/page.tsx
@@ -11,7 +11,7 @@ import type { ActivityEvent, ActivityCategory, ActivityActor, ActivityChange, Sc
 
 interface ApiCallRecord {
   ts: number;
-  type: "api" | "cache";
+  type: "api" | "cache" | "cdn-hit" | "cdn-miss" | "cdn-stale" | "cdn-error";
   method: string;
   symbol?: string;
 }
@@ -20,6 +20,10 @@ interface ApiStatsData {
   total: number;
   apiCalls: number;
   cacheHits: number;
+  cdnHits: number;
+  cdnMisses: number;
+  cdnStale: number;
+  cdnErrors: number;
   recentRate: number;
   last60s: ApiCallRecord[];
 }
@@ -645,9 +649,15 @@ export default function DevDashboard() {
             const s = state.apiStats;
             const total = s.apiCalls + s.cacheHits;
             const cachePercent = total > 0 ? ((s.cacheHits / total) * 100) : 0;
+            const cdnTotal = s.cdnHits + s.cdnMisses + s.cdnStale + s.cdnErrors;
+            const cdnHitRate = cdnTotal > 0 ? ((s.cdnHits / cdnTotal) * 100) : 0;
             const rateOk = s.recentRate <= 3;
             const recentApiCalls = s.last60s.filter((r) => r.type === 'api');
             const recentCacheHits = s.last60s.filter((r) => r.type === 'cache');
+            const recentCdnHits = s.last60s.filter((r) => r.type === 'cdn-hit');
+            const recentCdnMisses = s.last60s.filter((r) => r.type === 'cdn-miss');
+            const recentCdnStale = s.last60s.filter((r) => r.type === 'cdn-stale');
+            const recentCdnErrors = s.last60s.filter((r) => r.type === 'cdn-error');
             return (
               <div className={`mt-3 rounded-xl border p-4 ${rateOk ? 'border-surface-border bg-surface-raised' : 'border-amber-500/20 bg-amber-500/[0.04]'}`}>
                 <div className="flex items-center justify-between mb-3">
@@ -656,7 +666,7 @@ export default function DevDashboard() {
                     {s.recentRate} req/s {rateOk ? '(OK)' : '(HIGH)'}
                   </span>
                 </div>
-                <div className="grid grid-cols-4 gap-4">
+                <div className="grid grid-cols-5 gap-4">
                   {/* Rate gauge */}
                   <div>
                     <p className="text-lg font-bold tabular-nums">{s.recentRate}<span className="text-text-muted text-xs font-normal">/s</span></p>
@@ -676,9 +686,23 @@ export default function DevDashboard() {
                     </div>
                     <div className="flex items-baseline gap-1 mt-0.5">
                       <span className="text-lg font-bold tabular-nums text-emerald-400">{s.cacheHits}</span>
-                      <span className="text-[10px] text-text-muted">Cache</span>
+                      <span className="text-[10px] text-text-muted">Memory</span>
                     </div>
-                    <p className="text-[10px] text-text-muted mt-1">{cachePercent.toFixed(0)}% hit rate</p>
+                    <p className="text-[10px] text-text-muted mt-1">{cachePercent.toFixed(0)}% mem hit</p>
+                  </div>
+
+                  {/* CDN stats */}
+                  <div>
+                    <p className="text-[10px] text-text-muted font-semibold mb-1.5">CDN (Candles)</p>
+                    <div className="flex items-baseline gap-1">
+                      <span className="text-sm font-bold tabular-nums text-violet-400">{s.cdnHits}</span>
+                      <span className="text-[9px] text-text-muted">HIT</span>
+                    </div>
+                    <div className="flex items-baseline gap-1 mt-0.5">
+                      <span className="text-sm font-bold tabular-nums text-amber-400">{s.cdnMisses + s.cdnStale}</span>
+                      <span className="text-[9px] text-text-muted">MISS/STALE</span>
+                    </div>
+                    {cdnTotal > 0 && <p className="text-[10px] text-text-muted mt-1">{cdnHitRate.toFixed(0)}% CDN hit</p>}
                   </div>
 
                   {/* Last 60s breakdown */}
@@ -686,24 +710,44 @@ export default function DevDashboard() {
                     <p className="text-[10px] text-text-muted font-semibold mb-1.5">Last 60s</p>
                     <div className="flex items-baseline gap-1">
                       <span className="text-sm font-bold tabular-nums text-cyan-400">{recentApiCalls.length}</span>
-                      <span className="text-[9px] text-text-muted">NSE calls</span>
+                      <span className="text-[9px] text-text-muted">NSE</span>
                     </div>
                     <div className="flex items-baseline gap-1 mt-0.5">
                       <span className="text-sm font-bold tabular-nums text-emerald-400">{recentCacheHits.length}</span>
-                      <span className="text-[9px] text-text-muted">cache hits</span>
+                      <span className="text-[9px] text-text-muted">mem</span>
+                    </div>
+                    <div className="flex items-baseline gap-1 mt-0.5">
+                      <span className="text-sm font-bold tabular-nums text-violet-400">{recentCdnHits.length}</span>
+                      <span className="text-[9px] text-text-muted">CDN</span>
+                      {(recentCdnStale.length > 0 || recentCdnErrors.length > 0 || recentCdnMisses.length > 0) && (
+                        <span className="text-[9px] text-text-muted/50">({recentCdnMisses.length}m {recentCdnStale.length}s {recentCdnErrors.length}e)</span>
+                      )}
                     </div>
                   </div>
 
                   {/* Recent API methods */}
                   <div>
-                    <p className="text-[10px] text-text-muted font-semibold mb-1.5">Recent API calls</p>
+                    <p className="text-[10px] text-text-muted font-semibold mb-1.5">Recent calls</p>
                     <div className="space-y-0.5 max-h-[60px] overflow-y-auto scrollbar-thin">
-                      {recentApiCalls.length === 0 ? (
+                      {s.last60s.length === 0 ? (
                         <span className="text-[10px] text-text-muted/50">None in last 60s</span>
-                      ) : recentApiCalls.slice(-6).reverse().map((r, i) => (
+                      ) : s.last60s.slice(-8).reverse().map((r, i) => (
                         <div key={i} className="flex items-center gap-1.5 text-[9px]">
-                          <span className="w-1 h-1 rounded-full bg-cyan-400 flex-shrink-0" />
+                          <span className={`w-1 h-1 rounded-full flex-shrink-0 ${
+                            r.type === 'api' ? 'bg-cyan-400'
+                            : r.type === 'cache' ? 'bg-emerald-400'
+                            : r.type === 'cdn-hit' ? 'bg-violet-400'
+                            : r.type === 'cdn-stale' ? 'bg-amber-400'
+                            : r.type === 'cdn-error' ? 'bg-red-400'
+                            : 'bg-blue-400'
+                          }`} />
                           <span className="text-text-secondary font-mono truncate">{r.method}{r.symbol ? ` (${r.symbol})` : ''}</span>
+                          <span className={`text-[8px] ${
+                            r.type === 'cdn-hit' ? 'text-violet-400/60'
+                            : r.type === 'cdn-stale' ? 'text-amber-400/60'
+                            : r.type === 'cdn-error' ? 'text-red-400/60'
+                            : ''
+                          }`}>{r.type.startsWith('cdn') ? r.type.replace('cdn-', '') : ''}</span>
                         </div>
                       ))}
                     </div>

--- a/src/components/alert-panel.tsx
+++ b/src/components/alert-panel.tsx
@@ -10,97 +10,190 @@ export function AlertPanel({ alerts }: { alerts: Alert[] }) {
 
   if (recentAlerts.length === 0) return null;
 
+  const breakoutAlerts = recentAlerts.filter((a) => (a.alertType ?? "breakout") === "breakout");
+  const lowBreakAlerts = recentAlerts.filter((a) => a.alertType === "low-break");
+
   return (
-    <section className="mt-10">
-      <div className="mb-4 flex items-center gap-3">
-        <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-accent/10">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="text-accent">
-            <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" />
-          </svg>
+    <section className="mt-10 space-y-8">
+      {/* ── Breakout Alerts ───────────────────────────────────────────── */}
+      {breakoutAlerts.length > 0 && (
+        <div>
+          <div className="mb-4 flex items-center gap-3">
+            <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-accent/10">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="text-accent">
+                <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" />
+              </svg>
+            </div>
+            <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">
+              Breakout Alerts
+            </h2>
+            <span className="rounded-full bg-accent/10 px-2 py-0.5 text-[10px] font-bold tabular-nums text-accent">
+              {breakoutAlerts.length}
+            </span>
+            <div className="flex-1 border-t border-surface-border/40" />
+          </div>
+          <div className="overflow-hidden rounded-2xl border border-surface-border bg-surface-raised">
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-surface-border bg-surface-overlay/30 text-left text-xs text-text-muted">
+                    <th className="px-5 py-3.5 font-medium">Stock</th>
+                    <th className="px-4 py-3.5 font-medium text-right">Today High</th>
+                    <th className="px-4 py-3.5 font-medium text-right">5d Max High</th>
+                    <th className="px-4 py-3.5 font-medium text-right">High Break</th>
+                    <th className="px-4 py-3.5 font-medium text-right">Today Vol</th>
+                    <th className="px-4 py-3.5 font-medium text-right">5d Max Vol</th>
+                    <th className="px-4 py-3.5 font-medium text-right">Vol Break</th>
+                    <th className="px-4 py-3.5 font-medium text-right">Time</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {breakoutAlerts.map((alert, i) => (
+                    <tr
+                      key={alert.id}
+                      className="animate-fade-in border-b border-surface-border/30 transition-colors duration-200 hover:bg-surface-overlay/20"
+                      style={{ animationDelay: `${i * 50}ms` }}
+                    >
+                      <td className="px-5 py-3.5">
+                        <div className="flex items-center gap-2.5">
+                          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-accent/10 text-[10px] font-bold text-accent">
+                            {alert.symbol.slice(0, 2)}
+                          </div>
+                          <div>
+                            <div className="font-semibold">{alert.symbol}</div>
+                            <div className="text-[11px] text-text-muted">{alert.name}</div>
+                          </div>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3.5 text-right font-medium tabular-nums text-accent">
+                        &#x20B9;{alert.todayHigh.toLocaleString("en-IN")}
+                      </td>
+                      <td className="px-4 py-3.5 text-right tabular-nums text-text-secondary">
+                        &#x20B9;{alert.prevMaxHigh.toLocaleString("en-IN")}
+                      </td>
+                      <td className="px-4 py-3.5 text-right">
+                        <span className="inline-flex items-center gap-1 rounded-md bg-accent/10 px-2 py-0.5 text-xs font-bold tabular-nums text-accent">
+                          <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3">
+                            <polyline points="18 15 12 9 6 15" />
+                          </svg>
+                          {alert.highBreakPercent.toFixed(1)}%
+                        </span>
+                      </td>
+                      <td className="px-4 py-3.5 text-right font-medium tabular-nums text-accent">
+                        {formatVolume(alert.todayVolume)}
+                      </td>
+                      <td className="px-4 py-3.5 text-right tabular-nums text-text-secondary">
+                        {formatVolume(alert.prevMaxVolume)}
+                      </td>
+                      <td className="px-4 py-3.5 text-right">
+                        <span className="inline-flex items-center gap-1 rounded-md bg-accent/10 px-2 py-0.5 text-xs font-bold tabular-nums text-accent">
+                          <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3">
+                            <polyline points="18 15 12 9 6 15" />
+                          </svg>
+                          {alert.volumeBreakPercent.toFixed(1)}%
+                        </span>
+                      </td>
+                      <td className="px-4 py-3.5 text-right text-xs text-text-muted">
+                        {new Date(alert.triggeredAt).toLocaleString("en-IN", {
+                          day: "2-digit",
+                          month: "short",
+                          hour: "2-digit",
+                          minute: "2-digit",
+                        })}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
         </div>
-        <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">
-          Recent Breakout Alerts
-        </h2>
-        <span className="rounded-full bg-accent/10 px-2 py-0.5 text-[10px] font-bold tabular-nums text-accent">
-          {recentAlerts.length}
-        </span>
-        <div className="flex-1 border-t border-surface-border/40" />
-      </div>
-      <div className="overflow-hidden rounded-2xl border border-surface-border bg-surface-raised">
-        <div className="overflow-x-auto">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-surface-border bg-surface-overlay/30 text-left text-xs text-text-muted">
-                <th className="px-5 py-3.5 font-medium">Stock</th>
-                <th className="px-4 py-3.5 font-medium text-right">Today High</th>
-                <th className="px-4 py-3.5 font-medium text-right">5d Max High</th>
-                <th className="px-4 py-3.5 font-medium text-right">High Break</th>
-                <th className="px-4 py-3.5 font-medium text-right">Today Vol</th>
-                <th className="px-4 py-3.5 font-medium text-right">5d Max Vol</th>
-                <th className="px-4 py-3.5 font-medium text-right">Vol Break</th>
-                <th className="px-4 py-3.5 font-medium text-right">Time</th>
-              </tr>
-            </thead>
-            <tbody>
-              {recentAlerts.map((alert, i) => (
-                <tr
-                  key={alert.id}
-                  className="animate-fade-in border-b border-surface-border/30 transition-colors duration-200 hover:bg-surface-overlay/20"
-                  style={{ animationDelay: `${i * 50}ms` }}
-                >
-                  <td className="px-5 py-3.5">
-                    <div className="flex items-center gap-2.5">
-                      <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-accent/10 text-[10px] font-bold text-accent">
-                        {alert.symbol.slice(0, 2)}
-                      </div>
-                      <div>
-                        <div className="font-semibold">{alert.symbol}</div>
-                        <div className="text-[11px] text-text-muted">{alert.name}</div>
-                      </div>
-                    </div>
-                  </td>
-                  <td className="px-4 py-3.5 text-right font-medium tabular-nums text-accent">
-                    &#x20B9;{alert.todayHigh.toLocaleString("en-IN")}
-                  </td>
-                  <td className="px-4 py-3.5 text-right tabular-nums text-text-secondary">
-                    &#x20B9;{alert.prevMaxHigh.toLocaleString("en-IN")}
-                  </td>
-                  <td className="px-4 py-3.5 text-right">
-                    <span className="inline-flex items-center gap-1 rounded-md bg-accent/10 px-2 py-0.5 text-xs font-bold tabular-nums text-accent">
-                      <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3">
-                        <polyline points="18 15 12 9 6 15" />
-                      </svg>
-                      {alert.highBreakPercent.toFixed(1)}%
-                    </span>
-                  </td>
-                  <td className="px-4 py-3.5 text-right font-medium tabular-nums text-accent">
-                    {formatVolume(alert.todayVolume)}
-                  </td>
-                  <td className="px-4 py-3.5 text-right tabular-nums text-text-secondary">
-                    {formatVolume(alert.prevMaxVolume)}
-                  </td>
-                  <td className="px-4 py-3.5 text-right">
-                    <span className="inline-flex items-center gap-1 rounded-md bg-accent/10 px-2 py-0.5 text-xs font-bold tabular-nums text-accent">
-                      <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3">
-                        <polyline points="18 15 12 9 6 15" />
-                      </svg>
-                      {alert.volumeBreakPercent.toFixed(1)}%
-                    </span>
-                  </td>
-                  <td className="px-4 py-3.5 text-right text-xs text-text-muted">
-                    {new Date(alert.triggeredAt).toLocaleString("en-IN", {
-                      day: "2-digit",
-                      month: "short",
-                      hour: "2-digit",
-                      minute: "2-digit",
-                    })}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+      )}
+
+      {/* ── Low-Break Alerts ──────────────────────────────────────────── */}
+      {lowBreakAlerts.length > 0 && (
+        <div>
+          <div className="mb-4 flex items-center gap-3">
+            <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-red-500/10">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="text-red-400">
+                <polyline points="22 17 13.5 8.5 8.5 13.5 2 7" />
+                <polyline points="16 17 22 17 22 11" />
+              </svg>
+            </div>
+            <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">
+              Low-Break Alerts
+            </h2>
+            <span className="rounded-full bg-red-500/10 px-2 py-0.5 text-[10px] font-bold tabular-nums text-red-400">
+              {lowBreakAlerts.length}
+            </span>
+            <div className="flex-1 border-t border-surface-border/40" />
+          </div>
+          <div className="overflow-hidden rounded-2xl border border-red-500/15 bg-surface-raised">
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-surface-border bg-surface-overlay/30 text-left text-xs text-text-muted">
+                    <th className="px-5 py-3.5 font-medium">Stock</th>
+                    <th className="px-4 py-3.5 font-medium text-right">LTP</th>
+                    <th className="px-4 py-3.5 font-medium text-right">10d Low</th>
+                    <th className="px-4 py-3.5 font-medium text-right">Break %</th>
+                    <th className="px-4 py-3.5 font-medium text-right">Day Change</th>
+                    <th className="px-4 py-3.5 font-medium text-right">Time</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {lowBreakAlerts.map((alert, i) => (
+                    <tr
+                      key={alert.id}
+                      className="animate-fade-in border-b border-surface-border/30 transition-colors duration-200 hover:bg-red-500/[0.03]"
+                      style={{ animationDelay: `${i * 50}ms` }}
+                    >
+                      <td className="px-5 py-3.5">
+                        <div className="flex items-center gap-2.5">
+                          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-red-500/10 text-[10px] font-bold text-red-400">
+                            {alert.symbol.slice(0, 2)}
+                          </div>
+                          <div>
+                            <div className="font-semibold">{alert.symbol}</div>
+                            <div className="text-[11px] text-text-muted">{alert.name}</div>
+                          </div>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3.5 text-right font-medium tabular-nums text-red-400">
+                        &#x20B9;{alert.todayClose.toLocaleString("en-IN")}
+                      </td>
+                      <td className="px-4 py-3.5 text-right tabular-nums text-text-secondary">
+                        &#x20B9;{alert.prev10DayLow.toLocaleString("en-IN")}
+                      </td>
+                      <td className="px-4 py-3.5 text-right">
+                        <span className="inline-flex items-center gap-1 rounded-md bg-red-500/10 px-2 py-0.5 text-xs font-bold tabular-nums text-red-400">
+                          <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3">
+                            <polyline points="6 9 12 15 18 9" />
+                          </svg>
+                          -{alert.lowBreakPercent.toFixed(1)}%
+                        </span>
+                      </td>
+                      <td className="px-4 py-3.5 text-right">
+                        <span className={`text-xs font-semibold tabular-nums ${alert.todayChange >= 0 ? "text-accent" : "text-red-400"}`}>
+                          {alert.todayChange >= 0 ? "+" : ""}{alert.todayChange.toFixed(2)}%
+                        </span>
+                      </td>
+                      <td className="px-4 py-3.5 text-right text-xs text-text-muted">
+                        {new Date(alert.triggeredAt).toLocaleString("en-IN", {
+                          day: "2-digit",
+                          month: "short",
+                          hour: "2-digit",
+                          minute: "2-digit",
+                        })}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
         </div>
-      </div>
+      )}
     </section>
   );
 }

--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -84,6 +84,11 @@ export function Dashboard({
           data.results.filter((r: ScanResult) => r.triggered),
           notifyCooldownRef.current
         );
+        for (const r of data.results as ScanResult[]) {
+          if (r.lowBreakTriggered) {
+            notifyLowBreak(r, notifyCooldownRef.current);
+          }
+        }
       }
     } catch {
       // scan failed silently — results stay as-is

--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -83,49 +83,88 @@ export function NotificationBell({
                 <p className="mt-1 text-xs text-text-muted">Run a scan to check for breakouts</p>
               </div>
             ) : (
-              alerts.slice(0, 20).map((alert, i) => (
-                <button
-                  key={alert.id}
-                  onClick={() => onMarkRead(alert.id)}
-                  className={`w-full border-b border-surface-border/40 px-4 py-3 text-left transition-all duration-200 hover:bg-surface-overlay/60 ${
-                    !alert.read ? "bg-accent/[0.04]" : ""
-                  }`}
-                  style={{ animationDelay: `${i * 30}ms` }}
-                >
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="flex items-center gap-2.5">
-                      {!alert.read && (
-                        <span className="mt-0.5 h-2 w-2 flex-shrink-0 rounded-full bg-accent shadow-sm shadow-accent/40" />
-                      )}
-                      <div>
-                        <span className="text-sm font-semibold">{alert.symbol}</span>
-                        <span className="ml-2 text-xs text-text-muted">{alert.name}</span>
+              alerts.slice(0, 20).map((alert, i) => {
+                const isLowBreak = alert.alertType === "low-break";
+                return (
+                  <button
+                    key={alert.id}
+                    onClick={() => onMarkRead(alert.id)}
+                    className={`w-full border-b border-surface-border/40 px-4 py-3 text-left transition-all duration-200 hover:bg-surface-overlay/60 ${
+                      !alert.read
+                        ? isLowBreak ? "bg-red-500/[0.04]" : "bg-accent/[0.04]"
+                        : ""
+                    }`}
+                    style={{ animationDelay: `${i * 30}ms` }}
+                  >
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="flex items-center gap-2.5">
+                        {!alert.read && (
+                          <span className={`mt-0.5 h-2 w-2 flex-shrink-0 rounded-full shadow-sm ${
+                            isLowBreak ? "bg-red-400 shadow-red-400/40" : "bg-accent shadow-accent/40"
+                          }`} />
+                        )}
+                        <div>
+                          <span className="text-sm font-semibold">{alert.symbol}</span>
+                          <span className="ml-2 text-xs text-text-muted">{alert.name}</span>
+                        </div>
                       </div>
+                      {isLowBreak ? (
+                        <span className="flex items-center gap-1 flex-shrink-0 rounded-md bg-red-500/15 px-1.5 py-0.5 text-[10px] font-bold tracking-wide text-red-400">
+                          <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3">
+                            <polyline points="6 9 12 15 18 9" />
+                          </svg>
+                          LOW BREAK
+                        </span>
+                      ) : (
+                        <span className="flex items-center gap-1 flex-shrink-0 rounded-md bg-accent/15 px-1.5 py-0.5 text-[10px] font-bold tracking-wide text-accent">
+                          <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3">
+                            <polyline points="18 15 12 9 6 15" />
+                          </svg>
+                          BREAKOUT
+                        </span>
+                      )}
                     </div>
-                    <span className="flex-shrink-0 rounded-md bg-accent/15 px-1.5 py-0.5 text-[10px] font-bold tracking-wide text-accent">
-                      BREAKOUT
-                    </span>
-                  </div>
-                  <div className={`mt-2 grid grid-cols-2 gap-x-4 gap-y-1 text-xs ${!alert.read ? "ml-[18px]" : ""}`}>
-                    <div className="text-text-secondary">
-                      High: <span className="text-accent tabular-nums">&#x20B9;{alert.todayHigh.toLocaleString("en-IN")}</span>
-                      <span className="text-text-muted"> vs &#x20B9;{alert.prevMaxHigh.toLocaleString("en-IN")}</span>
+
+                    {isLowBreak ? (
+                      <div className={`mt-2 grid grid-cols-2 gap-x-4 gap-y-1 text-xs ${!alert.read ? "ml-[18px]" : ""}`}>
+                        <div className="text-text-secondary">
+                          LTP: <span className="text-red-400 tabular-nums">&#x20B9;{alert.todayClose.toLocaleString("en-IN")}</span>
+                        </div>
+                        <div className="text-text-secondary">
+                          10d Low: <span className="text-text-muted tabular-nums">&#x20B9;{alert.prev10DayLow.toLocaleString("en-IN")}</span>
+                        </div>
+                        <div className="text-text-secondary col-span-2">
+                          Break: <span className="text-red-400 tabular-nums">-{alert.lowBreakPercent.toFixed(1)}%</span>
+                          <span className="text-text-muted ml-2">Day: </span>
+                          <span className={`tabular-nums ${alert.todayChange >= 0 ? "text-accent" : "text-red-400"}`}>
+                            {alert.todayChange >= 0 ? "+" : ""}{alert.todayChange.toFixed(2)}%
+                          </span>
+                        </div>
+                      </div>
+                    ) : (
+                      <div className={`mt-2 grid grid-cols-2 gap-x-4 gap-y-1 text-xs ${!alert.read ? "ml-[18px]" : ""}`}>
+                        <div className="text-text-secondary">
+                          High: <span className="text-accent tabular-nums">&#x20B9;{alert.todayHigh.toLocaleString("en-IN")}</span>
+                          <span className="text-text-muted"> vs &#x20B9;{alert.prevMaxHigh.toLocaleString("en-IN")}</span>
+                        </div>
+                        <div className="text-text-secondary">
+                          Vol: <span className="text-accent tabular-nums">{formatVolume(alert.todayVolume)}</span>
+                          <span className="text-text-muted"> vs {formatVolume(alert.prevMaxVolume)}</span>
+                        </div>
+                      </div>
+                    )}
+
+                    <div className={`mt-1.5 text-[10px] text-text-muted ${!alert.read ? "ml-[18px]" : ""}`}>
+                      {new Date(alert.triggeredAt).toLocaleString("en-IN", {
+                        day: "2-digit",
+                        month: "short",
+                        hour: "2-digit",
+                        minute: "2-digit",
+                      })}
                     </div>
-                    <div className="text-text-secondary">
-                      Vol: <span className="text-accent tabular-nums">{formatVolume(alert.todayVolume)}</span>
-                      <span className="text-text-muted"> vs {formatVolume(alert.prevMaxVolume)}</span>
-                    </div>
-                  </div>
-                  <div className={`mt-1.5 text-[10px] text-text-muted ${!alert.read ? "ml-[18px]" : ""}`}>
-                    {new Date(alert.triggeredAt).toLocaleString("en-IN", {
-                      day: "2-digit",
-                      month: "short",
-                      hour: "2-digit",
-                      minute: "2-digit",
-                    })}
-                  </div>
-                </button>
-              ))
+                  </button>
+                );
+              })
             )}
           </div>
         </div>

--- a/src/components/stock-card.tsx
+++ b/src/components/stock-card.tsx
@@ -25,6 +25,7 @@ export function StockCard({
   const isLive = result.dataSource === "live";
   const highBreaks = hasData && !isStale && result.todayHigh > result.prevMaxHigh;
   const volBreaks = hasData && !isStale && result.todayVolume > result.prevMaxVolume;
+  const lowBreaks = hasData && !isStale && result.lowBreakTriggered;
 
   // Animate star toggle transitions
   useEffect(() => {
@@ -73,19 +74,24 @@ export function StockCard({
           ? "border-warn/30 bg-surface-raised"
           : result.triggered
             ? "border-accent/30 card-glow bg-surface-raised"
-            : closeWatch
-              ? "border-amber-400/25 bg-surface-raised hover:shadow-xl hover:shadow-amber-400/5"
-              : "border-surface-border bg-surface-raised hover:border-surface-border/80 hover:shadow-xl hover:shadow-black/20"
+            : lowBreaks
+              ? "border-red-500/30 bg-surface-raised"
+              : closeWatch
+                ? "border-amber-400/25 bg-surface-raised hover:shadow-xl hover:shadow-amber-400/5"
+                : "border-surface-border bg-surface-raised hover:border-surface-border/80 hover:shadow-xl hover:shadow-black/20"
       }`}
     >
       {/* Top edge highlight */}
       {result.triggered && !isStale && (
         <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-accent/60 to-transparent" />
       )}
+      {lowBreaks && !result.triggered && (
+        <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-red-500/60 to-transparent" />
+      )}
       {isStale && (
         <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-warn/60 to-transparent" />
       )}
-      {closeWatch && !result.triggered && !isStale && (
+      {closeWatch && !result.triggered && !lowBreaks && !isStale && (
         <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-amber-400/50 to-transparent" />
       )}
 
@@ -159,6 +165,12 @@ export function StockCard({
                 <span className="inline-flex items-center gap-1 rounded-md bg-accent/15 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-accent">
                   <span className="h-1 w-1 rounded-full bg-accent animate-pulse" />
                   Breakout
+                </span>
+              )}
+              {lowBreaks && (
+                <span className="inline-flex items-center gap-1 rounded-md bg-red-500/15 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-red-400">
+                  <span className="h-1 w-1 rounded-full bg-red-400 animate-pulse" />
+                  Low Break
                 </span>
               )}
               {isLive && (
@@ -240,6 +252,7 @@ export function StockCard({
         <div className="mt-4 flex gap-2">
           <StatusPill active={highBreaks} label="High Break" />
           <StatusPill active={volBreaks} label="Vol Break" />
+          <StatusPill active={lowBreaks} label="Low Break" variant={lowBreaks ? "danger" : undefined} />
         </div>
       )}
 
@@ -315,17 +328,28 @@ function MetricBar({
   );
 }
 
-function StatusPill({ active, label }: { active: boolean; label: string }) {
+function StatusPill({ active, label, variant }: { active: boolean; label: string; variant?: "danger" }) {
+  const isDanger = variant === "danger";
   return (
     <span
       className={`inline-flex items-center gap-1 rounded-lg px-2.5 py-1 text-[11px] font-medium transition-colors ${
-        active ? "bg-accent/10 text-accent" : "bg-surface-overlay text-text-muted"
+        active
+          ? isDanger
+            ? "bg-red-500/10 text-red-400"
+            : "bg-accent/10 text-accent"
+          : "bg-surface-overlay text-text-muted"
       }`}
     >
       {active ? (
-        <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3">
-          <polyline points="20 6 9 17 4 12" />
-        </svg>
+        isDanger ? (
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3">
+            <polyline points="6 9 12 15 18 9" />
+          </svg>
+        ) : (
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3">
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
+        )
       ) : (
         <span className="text-[8px]">&mdash;</span>
       )}

--- a/src/lib/nse-client.ts
+++ b/src/lib/nse-client.ts
@@ -7,7 +7,7 @@ import type { DayData, NiftyIndex } from "./types";
 
 interface ApiCallRecord {
   ts: number;       // epoch ms
-  type: "api" | "cache";
+  type: "api" | "cache" | "cdn-hit" | "cdn-miss" | "cdn-stale" | "cdn-error";
   method: string;   // e.g. "getHistoricalData", "getCurrentDayData"
   symbol?: string;
 }
@@ -15,15 +15,22 @@ interface ApiCallRecord {
 const API_CALL_LOG: ApiCallRecord[] = [];
 const MAX_CALL_LOG = 500;
 
-function recordCall(type: "api" | "cache", method: string, symbol?: string) {
+function recordCall(type: ApiCallRecord["type"], method: string, symbol?: string) {
   API_CALL_LOG.push({ ts: Date.now(), type, method, symbol });
   if (API_CALL_LOG.length > MAX_CALL_LOG) API_CALL_LOG.splice(0, API_CALL_LOG.length - MAX_CALL_LOG);
 }
+
+/** Expose recordCall so the scanner can log CDN hits/misses */
+export { recordCall };
 
 export function getApiStats(): {
   total: number;
   apiCalls: number;
   cacheHits: number;
+  cdnHits: number;
+  cdnMisses: number;
+  cdnStale: number;
+  cdnErrors: number;
   recentRate: number;   // API calls per second in last 60s
   last60s: ApiCallRecord[];
 } {
@@ -33,10 +40,18 @@ export function getApiStats(): {
   const recentApi = recent.filter((r) => r.type === "api");
   const allApi = API_CALL_LOG.filter((r) => r.type === "api");
   const allCache = API_CALL_LOG.filter((r) => r.type === "cache");
+  const allCdnHit = API_CALL_LOG.filter((r) => r.type === "cdn-hit");
+  const allCdnMiss = API_CALL_LOG.filter((r) => r.type === "cdn-miss");
+  const allCdnStale = API_CALL_LOG.filter((r) => r.type === "cdn-stale");
+  const allCdnError = API_CALL_LOG.filter((r) => r.type === "cdn-error");
   return {
     total: API_CALL_LOG.length,
     apiCalls: allApi.length,
     cacheHits: allCache.length,
+    cdnHits: allCdnHit.length,
+    cdnMisses: allCdnMiss.length,
+    cdnStale: allCdnStale.length,
+    cdnErrors: allCdnError.length,
     recentRate: recentApi.length > 0 ? parseFloat((recentApi.length / 60).toFixed(2)) : 0,
     last60s: recent,
   };

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -173,19 +173,27 @@ export async function getCloseWatchStocks(): Promise<WatchlistStock[]> {
   return (await loadWatchlist()).filter((s) => s.closeWatch);
 }
 
+/** Returns only today's alerts (for the main dashboard). */
 export async function getAlerts(): Promise<Alert[]> {
   const all = await loadAlerts();
-  const todayAlerts = filterTodayAlerts(all);
-
-  // If old alerts were pruned, persist the cleanup
-  if (todayAlerts.length < all.length) {
-    await saveAlerts(todayAlerts);
-  }
-
-  return todayAlerts.sort(
+  return filterTodayAlerts(all).sort(
     (a, b) =>
       new Date(b.triggeredAt).getTime() - new Date(a.triggeredAt).getTime()
   );
+}
+
+/** Returns ALL stored alerts across all dates (for the dev panel). */
+export async function getAllAlerts(): Promise<Alert[]> {
+  const all = await loadAlerts();
+  return all.sort(
+    (a, b) =>
+      new Date(b.triggeredAt).getTime() - new Date(a.triggeredAt).getTime()
+  );
+}
+
+/** Deletes all stored alerts. */
+export async function clearAlerts(): Promise<void> {
+  await saveAlerts([]);
 }
 
 export async function addAlert(alert: Alert): Promise<void> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -29,12 +29,18 @@ export interface ScanResult {
   todayChange: number;
   scannedAt: string;
   dataSource: DataSource;
+  lowBreakTriggered: boolean;
+  prev10DayLow: number;
+  lowBreakPercent: number;
 }
+
+export type AlertType = "breakout" | "low-break";
 
 export interface Alert {
   id: string;
   symbol: string;
   name: string;
+  alertType: AlertType;
   todayHigh: number;
   todayVolume: number;
   prevMaxHigh: number;
@@ -43,6 +49,8 @@ export interface Alert {
   volumeBreakPercent: number;
   todayClose: number;
   todayChange: number;
+  prev10DayLow: number;
+  lowBreakPercent: number;
   triggeredAt: string;
   read: boolean;
 }


### PR DESCRIPTION
## Summary of Changes

### New Files (3)

- **src/lib/baselines.ts**  
  Baseline service that computes 5-day max high/volume for each NIFTY 50 stock. Cached per trading day (IST) in memory. Fetches in batches of 5 to avoid NSE rate limits.

- **src/app/api/nifty50/route.ts**  
  API route that orchestrates snapshot + baselines + breakout discovery. Returns stock rows, breakout signals, baseline status, and watchlist membership.

- **src/components/nifty50-table.tsx**  
  Client-side table component with:
  - Auto-refresh (3 min during market hours)
  - Manual refresh button
  - Sortable columns
  - Collapse toggle
  - Status indicators

---

### Modified Files (6)

- **src/lib/types.ts**  
  Added 7 new types:
  - `Nifty50StockRow`
  - `Nifty50Snapshot`
  - `StockBaseline`
  - `BreakoutDiscovery`
  - `Nifty50TableResponse`
  - `Nifty50DevStats`

- **src/lib/nse-client.ts**  
  Added `getNifty50Snapshot()` using `getEquityStockIndices("NIFTY 50")` with:
  - 3-min cache TTL  
  - Stale fallback  
  - Dev stats tracking  

- **src/lib/store.ts**  
  Enhanced alert deduplication logic:
  - Now checks `symbol + alertType + date`
  - Previously checked only `symbol + date`

- **src/components/dashboard.tsx**  
  Integrated `<Nifty50Table />` between ticker and watchlist.

- **src/app/api/state/route.ts**  
  Added `nifty50Stats` (snapshot health + baseline availability) for dev panel.

- **src/app/dev/page.tsx**  
  Added Nifty 50 Table tracking panel with:
  - Last refresh time  
  - Snapshot fetch success/failure counts  
  - Baseline progress bar  
  - `nifty50-discovery` activity icon  

---

## Key Design Decisions

- **Single API call via `getEquityStockIndices("NIFTY 50")`**  
  Fetches all 50 stocks at once instead of 50 individual calls.

- **Baselines are computed once per trading day**  
  Historical data is fetched once and cached for the rest of the day.

- **Breakout discovery only for non-watchlist stocks**  
  Watchlist stocks are already scanned, avoiding duplicate alerts.

- **Graceful degradation**  
  - Stale data is served with visual indicators when NSE fails.  
  - "Possible breakout" badges are shown when data reliability is reduced.

- **No polling after market close**  
  The table fetches once and caches.