### PR TITLE
Enhance Nifty 50 alerts, visual cues, loading UX, and Dev portal

### DIFF
--- a/src/app/api/state/route.ts
+++ b/src/app/api/state/route.ts
@@ -20,6 +20,23 @@ export async function GET() {
   const closeWatchStocks = watchlist.filter((s) => s.closeWatch);
   const unreadAlerts = alerts.filter((a) => !a.read).length;
 
+  // Break down alerts by type
+  const nifty50Alerts = alerts.filter((a) => a.alertType === "breakout");
+  const scanAlerts = alerts.filter((a) => !a.alertType || a.alertType === "scan");
+
+  // Cache layer breakdown from apiStats
+  const apiStats = getApiStats();
+  const cacheLayers = {
+    historical: cacheStats,
+    snapshot: getNifty50SnapshotStats(),
+    apiThrottle: {
+      total: apiStats.total,
+      apiCalls: apiStats.apiCalls,
+      cacheHits: apiStats.cacheHits,
+      hitRate: apiStats.total > 0 ? Math.round((apiStats.cacheHits / apiStats.total) * 100) : 0,
+    },
+  };
+
   return NextResponse.json({
     market: { open: marketOpen },
     watchlist: {
@@ -30,11 +47,15 @@ export async function GET() {
     alerts: {
       total: alerts.length,
       unread: unreadAlerts,
+      nifty50Alerts: nifty50Alerts.length,
+      scanAlerts: scanAlerts.length,
+      recentSymbols: alerts.slice(0, 5).map((a) => a.symbol),
     },
     scan: scanMeta,
     cache: cacheStats,
+    cacheLayers,
     nifty: nifty ?? null,
-    apiStats: getApiStats(),
+    apiStats,
     nifty50Stats: {
       ...getNifty50SnapshotStats(),
       baselines: getBaselineStats(),

--- a/src/components/nifty50-table.tsx
+++ b/src/components/nifty50-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { isMarketHours, isExtendedHours } from "@/lib/market-hours";
 import type {
   Nifty50TableResponse,
@@ -14,6 +14,60 @@ const MARKET_CHECK_INTERVAL = 60_000;
 type SortKey = "symbol" | "lastPrice" | "pChange" | "dayHigh" | "totalTradedVolume";
 type SortDir = "asc" | "desc";
 
+/* ── Creative loading messages ──────────────────────────────────────── */
+
+const LOADING_MESSAGES_INITIAL = [
+  "Waking up the Nifty 50...",
+  "Dialing Dalal Street...",
+  "Convincing NSE to share secrets...",
+  "Herding 50 stocks into a table...",
+  "Asking the market what's up...",
+];
+
+const LOADING_MESSAGES_REFRESH = [
+  "Checking who actually broke out and who just faked a rally...",
+  "Separating real breakouts from bull traps...",
+  "Asking 50 stocks if they're feeling adventurous...",
+  "Refreshing... because markets don't wait for anyone",
+  "Hunting for stocks that broke their 5-day ceiling...",
+  "Rechecking the usual suspects...",
+  "Counting volume bars and questioning life choices...",
+  "Peeking at the orderbook while NSE isn't looking...",
+  "Comparing today's drama to last week's...",
+  "Running the breakout detector... beep boop...",
+];
+
+function pickRandom(arr: string[]): string {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+/* ── Heat indicator: visual strength bar ────────────────────────────── */
+
+function BreakStrength({ percent, type }: { percent: number; type: "high" | "volume" }) {
+  const capped = Math.min(Math.abs(percent), 20); // cap at 20% for bar width
+  const width = Math.max((capped / 20) * 100, 8);
+  const isStrong = Math.abs(percent) > 5;
+  const color = type === "high"
+    ? isStrong ? "bg-accent" : "bg-accent/60"
+    : isStrong ? "bg-blue-400" : "bg-blue-400/60";
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <div className="h-1 w-12 rounded-full bg-surface-overlay overflow-hidden">
+        <div
+          className={`h-full rounded-full transition-all duration-700 ${color}`}
+          style={{ width: `${width}%` }}
+        />
+      </div>
+      <span className={`text-[9px] font-semibold tabular-nums ${isStrong ? "text-accent" : "text-text-muted"}`}>
+        +{percent.toFixed(1)}%
+      </span>
+    </div>
+  );
+}
+
+/* ── Main component ─────────────────────────────────────────────────── */
+
 export function Nifty50Table() {
   const [data, setData] = useState<Nifty50TableResponse | null>(null);
   const [loading, setLoading] = useState(false);
@@ -22,14 +76,33 @@ export function Nifty50Table() {
   const [sortKey, setSortKey] = useState<SortKey>("pChange");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
   const [collapsed, setCollapsed] = useState(false);
+  const [loadingMsg, setLoadingMsg] = useState("");
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const fetchingRef = useRef(false);
   const hasFetchedRef = useRef(false);
+  const loadingMsgTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const startLoadingMessages = useCallback((isRefresh: boolean) => {
+    const pool = isRefresh ? LOADING_MESSAGES_REFRESH : LOADING_MESSAGES_INITIAL;
+    setLoadingMsg(pickRandom(pool));
+    // Cycle messages every 2.5s for long loads
+    loadingMsgTimerRef.current = setInterval(() => {
+      setLoadingMsg(pickRandom(LOADING_MESSAGES_REFRESH));
+    }, 2500);
+  }, []);
+
+  const stopLoadingMessages = useCallback(() => {
+    if (loadingMsgTimerRef.current) {
+      clearInterval(loadingMsgTimerRef.current);
+      loadingMsgTimerRef.current = null;
+    }
+  }, []);
 
   const fetchData = useCallback(async () => {
     if (fetchingRef.current) return;
     fetchingRef.current = true;
     setLoading(true);
+    startLoadingMessages(hasFetchedRef.current);
     try {
       const res = await fetch("/api/nifty50");
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -42,8 +115,9 @@ export function Nifty50Table() {
     } finally {
       setLoading(false);
       fetchingRef.current = false;
+      stopLoadingMessages();
     }
-  }, []);
+  }, [startLoadingMessages, stopLoadingMessages]);
 
   // Check market hours periodically
   useEffect(() => {
@@ -69,6 +143,11 @@ export function Nifty50Table() {
       }
     };
   }, [marketLive, fetchData]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => stopLoadingMessages();
+  }, [stopLoadingMessages]);
 
   const handleSort = (key: SortKey) => {
     if (sortKey === key) {
@@ -125,25 +204,38 @@ export function Nifty50Table() {
     discoveryMap.set(d.symbol, d);
   }
 
-  const breakoutCount = (data?.discoveries ?? []).filter((d) => d.breakout).length;
-  const possibleCount = (data?.discoveries ?? []).filter((d) => d.possibleBreakout).length;
-  const baselineUnavailableCount = (data?.discoveries ?? []).filter((d) => d.baselineUnavailable).length;
+  // Counts
+  const discoveries = data?.discoveries ?? [];
+  const breakoutCount = discoveries.filter((d) => d.breakout).length;
+  const highOnlyCount = discoveries.filter((d) => d.highBreak && !d.breakout).length;
+  const volOnlyCount = discoveries.filter((d) => d.volumeBreak && !d.breakout).length;
+  const possibleCount = discoveries.filter((d) => d.possibleBreakout).length;
+  const baselineUnavailableCount = discoveries.filter((d) => d.baselineUnavailable).length;
   const isStale = data?.snapshot.stale ?? false;
   const fetchSuccess = data?.snapshot.fetchSuccess ?? true;
 
+  // Market sentiment gauge
+  const gainers = data ? data.snapshot.stocks.filter((s) => s.pChange > 0).length : 0;
+  const losers = data ? data.snapshot.stocks.filter((s) => s.pChange < 0).length : 0;
+
   const lastUpdated = data?.snapshot.fetchedAt;
-  const timeSinceUpdate = lastUpdated
-    ? Math.floor((Date.now() - new Date(lastUpdated).getTime()) / 1000)
-    : null;
 
   return (
     <div className="animate-fade-in">
-      <div className="overflow-hidden rounded-2xl border border-surface-border bg-surface-raised">
+      <div className={`overflow-hidden rounded-2xl border bg-surface-raised transition-all duration-300 ${
+        breakoutCount > 0
+          ? "border-accent/25 shadow-[0_0_30px_-10px_rgba(0,212,170,0.1)]"
+          : "border-surface-border"
+      }`}>
         {/* Header */}
         <div className="flex items-center justify-between border-b border-surface-border px-5 py-3.5">
           <div className="flex items-center gap-3">
             <div className="flex items-center gap-2">
-              <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-blue-500/10 text-blue-400">
+              <div className={`flex h-7 w-7 items-center justify-center rounded-lg transition-colors duration-300 ${
+                breakoutCount > 0
+                  ? "bg-accent/15 text-accent"
+                  : "bg-blue-500/10 text-blue-400"
+              }`}>
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                   <rect x="3" y="3" width="7" height="7" />
                   <rect x="14" y="3" width="7" height="7" />
@@ -154,7 +246,21 @@ export function Nifty50Table() {
               <div>
                 <h2 className="text-sm font-bold tracking-tight">NIFTY 50</h2>
                 <p className="text-[10px] text-text-muted">
-                  {data ? `${data.snapshot.stocks.length} stocks` : "Loading..."}
+                  {data ? (
+                    <>
+                      {data.snapshot.stocks.length} stocks
+                      {data && (
+                        <span className="ml-1.5 text-text-muted/70">
+                          {gainers}
+                          <span className="text-accent/70">&#9650;</span>
+                          {" "}{losers}
+                          <span className="text-danger/70">&#9660;</span>
+                        </span>
+                      )}
+                    </>
+                  ) : (
+                    <span className="animate-pulse">Loading...</span>
+                  )}
                   {breakoutCount > 0 && (
                     <span className="ml-1.5 text-accent font-semibold">
                       {breakoutCount} breakout{breakoutCount > 1 ? "s" : ""}
@@ -231,7 +337,7 @@ export function Nifty50Table() {
                 <path d="M2.5 11.5a10 10 0 0 1 18.1-4.5" />
                 <path d="M21.5 12.5a10 10 0 0 1-18.1 4.5" />
               </svg>
-              {loading ? "Refreshing..." : "Refresh"}
+              {loading ? "Scanning..." : "Refresh"}
             </button>
 
             {/* Collapse toggle */}
@@ -254,13 +360,47 @@ export function Nifty50Table() {
           </div>
         </div>
 
+        {/* Creative loading banner (shows during refresh when data exists) */}
+        {loading && data && (
+          <div className="flex items-center gap-3 border-b border-surface-border bg-surface/60 px-5 py-2 animate-fade-in-fast">
+            <div className="flex items-center gap-2">
+              <div className="flex gap-0.5">
+                <span className="h-1.5 w-1.5 rounded-full bg-accent animate-bounce" style={{ animationDelay: "0ms" }} />
+                <span className="h-1.5 w-1.5 rounded-full bg-accent animate-bounce" style={{ animationDelay: "150ms" }} />
+                <span className="h-1.5 w-1.5 rounded-full bg-accent animate-bounce" style={{ animationDelay: "300ms" }} />
+              </div>
+              <span className="text-[10px] text-text-muted italic">{loadingMsg}</span>
+            </div>
+          </div>
+        )}
+
         {/* Discovery summary bar */}
-        {!collapsed && data && (breakoutCount > 0 || possibleCount > 0 || baselineUnavailableCount > 0) && (
+        {!collapsed && data && !loading && (breakoutCount > 0 || highOnlyCount > 0 || volOnlyCount > 0 || possibleCount > 0 || baselineUnavailableCount > 0) && (
           <div className="flex items-center gap-3 border-b border-surface-border bg-surface/60 px-5 py-2">
             {breakoutCount > 0 && (
               <span className="flex items-center gap-1.5 text-[10px] font-semibold text-accent">
-                <span className="h-1.5 w-1.5 rounded-full bg-accent animate-pulse" />
-                {breakoutCount} new breakout{breakoutCount > 1 ? "s" : ""} discovered
+                <span className="relative flex h-2 w-2">
+                  <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-accent opacity-60" />
+                  <span className="relative inline-flex h-2 w-2 rounded-full bg-accent" />
+                </span>
+                {breakoutCount} breakout{breakoutCount > 1 ? "s" : ""} confirmed
+              </span>
+            )}
+            {highOnlyCount > 0 && (
+              <span className="flex items-center gap-1.5 text-[10px] font-medium text-accent/60">
+                <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+                  <polyline points="18 15 12 9 6 15" />
+                </svg>
+                {highOnlyCount} high break{highOnlyCount > 1 ? "s" : ""}
+              </span>
+            )}
+            {volOnlyCount > 0 && (
+              <span className="flex items-center gap-1.5 text-[10px] font-medium text-blue-400/60">
+                <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+                  <rect x="6" y="4" width="4" height="16" />
+                  <rect x="14" y="10" width="4" height="10" />
+                </svg>
+                {volOnlyCount} vol surge{volOnlyCount > 1 ? "s" : ""}
               </span>
             )}
             {possibleCount > 0 && (
@@ -268,12 +408,12 @@ export function Nifty50Table() {
                 <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
                   <path d="M12 9v4M12 17h.01" />
                 </svg>
-                {possibleCount} possible (data stale)
+                {possibleCount} possible (stale data)
               </span>
             )}
             {baselineUnavailableCount > 0 && (
               <span className="text-[10px] text-text-muted">
-                {baselineUnavailableCount} missing baselines
+                {baselineUnavailableCount} no baseline
               </span>
             )}
             <span className="ml-auto text-[10px] text-text-muted">
@@ -304,7 +444,7 @@ export function Nifty50Table() {
                   <SortHeader label="Chg %" sortKey="pChange" currentKey={sortKey} dir={sortDir} onClick={handleSort} className="text-right w-[90px]" />
                   <SortHeader label="Day High" sortKey="dayHigh" currentKey={sortKey} dir={sortDir} onClick={handleSort} className="text-right w-[100px]" />
                   <SortHeader label="Volume" sortKey="totalTradedVolume" currentKey={sortKey} dir={sortDir} onClick={handleSort} className="text-right w-[100px]" />
-                  <th className="px-4 py-2.5 text-center w-[100px]">Signal</th>
+                  <th className="px-4 py-2.5 text-center w-[130px]">Signal</th>
                   <th className="px-4 py-2.5 text-center w-[80px]">Status</th>
                 </tr>
               </thead>
@@ -325,11 +465,18 @@ export function Nifty50Table() {
           </div>
         )}
 
-        {/* Loading skeleton */}
+        {/* Loading skeleton — first load */}
         {!data && loading && (
-          <div className="px-5 py-12 text-center">
-            <div className="mx-auto h-1 w-48 animate-shimmer rounded-full bg-surface-overlay" />
-            <p className="mt-3 text-xs text-text-muted">Loading NIFTY 50 data...</p>
+          <div className="px-5 py-14 text-center">
+            <div className="mx-auto flex items-center justify-center gap-1 mb-4">
+              <span className="h-2 w-2 rounded-full bg-accent/50 animate-bounce" style={{ animationDelay: "0ms" }} />
+              <span className="h-2 w-2 rounded-full bg-accent/50 animate-bounce" style={{ animationDelay: "100ms" }} />
+              <span className="h-2 w-2 rounded-full bg-accent/50 animate-bounce" style={{ animationDelay: "200ms" }} />
+              <span className="h-2 w-2 rounded-full bg-accent/50 animate-bounce" style={{ animationDelay: "300ms" }} />
+              <span className="h-2 w-2 rounded-full bg-accent/50 animate-bounce" style={{ animationDelay: "400ms" }} />
+            </div>
+            <p className="text-xs text-text-muted italic">{loadingMsg}</p>
+            <div className="mx-auto mt-3 h-1 w-48 animate-shimmer rounded-full bg-surface-overlay" />
           </div>
         )}
 
@@ -338,22 +485,32 @@ export function Nifty50Table() {
           <div className="flex items-center justify-between border-t border-surface-border px-5 py-2">
             <div className="flex items-center gap-4 text-[10px] text-text-muted">
               <span className="flex items-center gap-1.5">
+                <span className="relative flex h-2 w-2">
+                  <span className="absolute inline-flex h-full w-full rounded-full bg-accent opacity-30 animate-ping" />
+                  <span className="relative inline-flex h-2 w-2 rounded-full bg-accent" />
+                </span>
+                Breakout
+              </span>
+              <span className="flex items-center gap-1.5">
+                <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" className="text-accent/60">
+                  <polyline points="18 15 12 9 6 15" />
+                </svg>
+                High Break
+              </span>
+              <span className="flex items-center gap-1.5">
+                <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" className="text-blue-400/60">
+                  <rect x="6" y="4" width="4" height="16" />
+                  <rect x="14" y="10" width="4" height="10" />
+                </svg>
+                Vol Surge
+              </span>
+              <span className="flex items-center gap-1.5">
                 <span className="h-2 w-2 rounded-sm bg-blue-400/30" />
-                In Watchlist
+                Watchlist
               </span>
               <span className="flex items-center gap-1.5">
                 <span className="h-2 w-2 rounded-sm bg-amber-400/30" />
                 Close Watch
-              </span>
-              <span className="flex items-center gap-1.5">
-                <span className="h-1.5 w-1.5 rounded-full bg-accent" />
-                Breakout
-              </span>
-              <span className="flex items-center gap-1.5">
-                <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" className="text-warn">
-                  <path d="M12 9v4M12 17h.01" />
-                </svg>
-                Possible / Stale
               </span>
             </div>
             {marketLive && (
@@ -435,25 +592,34 @@ function StockRow({
   const volBreak = discovery?.volumeBreak ?? false;
 
   const rowBg = isBreakout
-    ? "bg-accent/[0.03]"
+    ? "bg-accent/[0.04] hover:bg-accent/[0.07]"
     : isPossible
-      ? "bg-warn/[0.02]"
-      : inCloseWatch
-        ? "bg-amber-400/[0.02]"
-        : inWatchlist
-          ? "bg-blue-500/[0.02]"
-          : "hover:bg-surface-overlay/20";
+      ? "bg-warn/[0.02] hover:bg-warn/[0.04]"
+      : (highBreak || volBreak) && !inWatchlist
+        ? "bg-accent/[0.02] hover:bg-accent/[0.04]"
+        : inCloseWatch
+          ? "bg-amber-400/[0.02] hover:bg-amber-400/[0.04]"
+          : inWatchlist
+            ? "bg-blue-500/[0.02] hover:bg-blue-500/[0.04]"
+            : "hover:bg-surface-overlay/20";
 
   return (
-    <tr className={`transition-colors ${rowBg}`}>
+    <tr className={`transition-colors duration-150 ${rowBg}`}>
       {/* Index */}
       <td className="px-4 py-2.5 text-[10px] tabular-nums text-text-muted">{index}</td>
 
       {/* Symbol + name */}
       <td className="px-4 py-2.5">
         <div className="flex items-center gap-2">
-          {/* Watchlist / close-watch indicator */}
-          {inCloseWatch ? (
+          {/* Watchlist / close-watch / breakout indicator */}
+          {isBreakout ? (
+            <span className="flex h-5 w-5 items-center justify-center rounded" title="Breakout detected">
+              <span className="relative flex h-2.5 w-2.5">
+                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-accent opacity-60" />
+                <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-accent shadow-[0_0_6px_rgba(0,212,170,0.5)]" />
+              </span>
+            </span>
+          ) : inCloseWatch ? (
             <span className="flex h-5 w-5 items-center justify-center rounded text-amber-400" title="Close Watch">
               <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="1">
                 <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
@@ -466,11 +632,17 @@ function StockRow({
                 <circle cx="12" cy="12" r="3" />
               </svg>
             </span>
+          ) : (highBreak || volBreak) ? (
+            <span className="flex h-5 w-5 items-center justify-center rounded" title="Partial break">
+              <span className="h-2 w-2 rounded-full bg-accent/40" />
+            </span>
           ) : (
             <span className="w-5" />
           )}
           <div>
-            <span className="text-xs font-semibold tracking-tight">{stock.symbol}</span>
+            <span className={`text-xs font-semibold tracking-tight ${isBreakout ? "text-accent" : ""}`}>
+              {stock.symbol}
+            </span>
             <p className="text-[10px] text-text-muted leading-tight truncate max-w-[120px]">{stock.name}</p>
           </div>
         </div>
@@ -479,26 +651,36 @@ function StockRow({
       {/* LTP */}
       <td className="px-4 py-2.5 text-right">
         <span className="text-xs font-semibold tabular-nums">
-          {stock.lastPrice > 0 ? `₹${stock.lastPrice.toLocaleString("en-IN")}` : "—"}
+          {stock.lastPrice > 0 ? `\u20B9${stock.lastPrice.toLocaleString("en-IN")}` : "\u2014"}
         </span>
       </td>
 
-      {/* Change % */}
+      {/* Change % — with visual bar */}
       <td className="px-4 py-2.5 text-right">
-        <span
-          className={`text-xs font-semibold tabular-nums ${
-            stock.pChange > 0 ? "text-accent" : stock.pChange < 0 ? "text-danger" : "text-text-muted"
-          }`}
-        >
-          {stock.pChange > 0 ? "+" : ""}
-          {stock.pChange.toFixed(2)}%
-        </span>
+        <div className="flex items-center justify-end gap-1.5">
+          {stock.pChange !== 0 && (
+            <div className="h-1 w-8 rounded-full bg-surface-overlay overflow-hidden">
+              <div
+                className={`h-full rounded-full transition-all duration-500 ${stock.pChange > 0 ? "bg-accent/50" : "bg-danger/50"}`}
+                style={{ width: `${Math.min(Math.abs(stock.pChange) * 15, 100)}%` }}
+              />
+            </div>
+          )}
+          <span
+            className={`text-xs font-semibold tabular-nums ${
+              stock.pChange > 0 ? "text-accent" : stock.pChange < 0 ? "text-danger" : "text-text-muted"
+            }`}
+          >
+            {stock.pChange > 0 ? "+" : ""}
+            {stock.pChange.toFixed(2)}%
+          </span>
+        </div>
       </td>
 
       {/* Day High */}
       <td className="px-4 py-2.5 text-right">
         <span className={`text-xs tabular-nums ${highBreak && !inWatchlist ? "text-accent font-semibold" : "text-text-secondary"}`}>
-          {stock.dayHigh > 0 ? `₹${stock.dayHigh.toLocaleString("en-IN")}` : "—"}
+          {stock.dayHigh > 0 ? `\u20B9${stock.dayHigh.toLocaleString("en-IN")}` : "\u2014"}
         </span>
       </td>
 
@@ -509,15 +691,22 @@ function StockRow({
         </span>
       </td>
 
-      {/* Signal */}
+      {/* Signal — enhanced with strength indicators */}
       <td className="px-4 py-2.5 text-center">
         {inWatchlist ? (
           <span className="text-[9px] text-text-muted/50 font-medium">Watchlist</span>
         ) : isBreakout ? (
-          <span className="inline-flex items-center gap-1 rounded-md bg-accent/15 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wider text-accent">
-            <span className="h-1 w-1 rounded-full bg-accent animate-pulse" />
-            Breakout
-          </span>
+          <div className="inline-flex flex-col items-center gap-0.5">
+            <span className="inline-flex items-center gap-1 rounded-md bg-accent/15 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wider text-accent card-glow">
+              <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3">
+                <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" />
+              </svg>
+              Breakout
+            </span>
+            <span className="text-[8px] text-accent/50 tabular-nums">
+              H+{discovery?.highBreakPercent?.toFixed(1)}% V+{discovery?.volumeBreakPercent?.toFixed(1)}%
+            </span>
+          </div>
         ) : isPossible ? (
           <span className="inline-flex items-center gap-1 rounded-md bg-warn/15 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wider text-warn">
             <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3">
@@ -530,15 +719,11 @@ function StockRow({
             No baseline
           </span>
         ) : highBreak ? (
-          <span className="inline-flex items-center gap-1 rounded-md bg-accent/10 px-1.5 py-0.5 text-[9px] font-medium text-accent/70">
-            High +{discovery?.highBreakPercent?.toFixed(1)}%
-          </span>
+          <BreakStrength percent={discovery?.highBreakPercent ?? 0} type="high" />
         ) : volBreak ? (
-          <span className="inline-flex items-center gap-1 rounded-md bg-accent/10 px-1.5 py-0.5 text-[9px] font-medium text-accent/70">
-            Vol +{discovery?.volumeBreakPercent?.toFixed(1)}%
-          </span>
+          <BreakStrength percent={discovery?.volumeBreakPercent ?? 0} type="volume" />
         ) : (
-          <span className="text-[9px] text-text-muted/30">—</span>
+          <span className="text-[9px] text-text-muted/30">&mdash;</span>
         )}
       </td>
 
@@ -559,7 +744,7 @@ function StockRow({
             </span>
           )}
           {!inWatchlist && !snapshotStale && (
-            <span className="text-[9px] text-text-muted/30">—</span>
+            <span className="text-[9px] text-text-muted/30">&mdash;</span>
           )}
         </div>
       </td>
@@ -571,6 +756,6 @@ function formatVol(vol: number): string {
   if (vol >= 10_000_000) return `${(vol / 10_000_000).toFixed(2)}Cr`;
   if (vol >= 100_000) return `${(vol / 100_000).toFixed(2)}L`;
   if (vol >= 1_000) return `${(vol / 1_000).toFixed(1)}K`;
-  if (vol === 0) return "—";
+  if (vol === 0) return "\u2014";
   return vol.toString();
 }

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -168,7 +168,7 @@ export async function getAlerts(): Promise<Alert[]> {
   );
 }
 
-export async function addAlert(alert: Alert): Promise<void> {
+export async function addAlert(alert: Alert): Promise<boolean> {
   const alerts = await loadAlerts();
   const existing = alerts.find(
     (a) =>
@@ -179,7 +179,9 @@ export async function addAlert(alert: Alert): Promise<void> {
   if (!existing) {
     alerts.push(alert);
     await saveAlerts(alerts);
+    return true;
   }
+  return false;
 }
 
 export async function markAlertRead(id: string): Promise<void> {


### PR DESCRIPTION
Alert fixes:
- addAlert now returns boolean for dedup feedback
- Nifty 50 route logs alert-fired activity for each new alert
- Discovery summary includes high-only and vol-only break counts

Nifty 50 table visual enhancements:
- Creative loading messages that cycle during refresh ("Checking who actually broke out and who just faked a rally...")
- Breakout rows glow with accent border/shadow
- Strength indicator bars for partial breaks (high/volume)
- Mini change-% bars inline with price change column
- Pulsing breakout dot replaces watchlist icon for breakout rows
- Market sentiment gauge (gainers/losers count in header)
- Bouncing dot animation during loading

Dev portal improvements:
- Alert breakdown card: N50 vs scan alert split with source dots
- Cache card shows hit rate bar inline
- New Cache Layers panel: historical, snapshot, API throttle with per-layer TTL, success rates, and visual breakdown
- New Action Flow section: horizontal timeline visualization of user and system actions grouped into sessions by time gaps with hover tooltips, color-coded nodes, and flow legend
- State API exposes cacheLayers, alert breakdown, recent symbols

https://claude.ai/code/session_01MXmozZUHBZo2KvgWXtAaWW