### PR TITLE
feat: redesign dev console with two-column layout and action flow hero

### DIFF
--- a/src/app/dev/page.tsx
+++ b/src/app/dev/page.tsx
@@ -5,10 +5,6 @@ import gsap from 'gsap';
 import type { LogEntry, LogLevel } from '@/lib/logger';
 import type { ActivityEvent, ActivityCategory, ActivityActor, ActivityChange, ScanMeta, NiftyIndex } from '@/lib/types';
 
-/* ═══════════════════════════════════════════════════════════════════════
- * Types
- * ═══════════════════════════════════════════════════════════════════════ */
-
 interface ApiCallRecord {
   ts: number;
   type: "api" | "cache";
@@ -68,10 +64,6 @@ interface SystemState {
 
 type TimelineFilter = 'all' | ActivityCategory;
 
-/* ═══════════════════════════════════════════════════════════════════════
- * Action icons & category styling
- * ═══════════════════════════════════════════════════════════════════════ */
-
 const CAT_STYLES: Record<ActivityCategory, { border: string; bg: string; text: string; label: string }> = {
   user:    { border: 'border-blue-500/25',    bg: 'bg-blue-500/10',    text: 'text-blue-400',    label: 'User' },
   system:  { border: 'border-emerald-500/25', bg: 'bg-emerald-500/10', text: 'text-emerald-400', label: 'System' },
@@ -112,10 +104,6 @@ function ActionIcon({ action }: { action: string }) {
   }
 }
 
-/* ═══════════════════════════════════════════════════════════════════════
- * Time formatting
- * ═══════════════════════════════════════════════════════════════════════ */
-
 function timeAgo(iso: string): string {
   const diff = Date.now() - new Date(iso).getTime();
   const secs = Math.floor(diff / 1000);
@@ -132,57 +120,45 @@ function formatTime(iso: string): string {
   return new Date(iso).toLocaleTimeString('en-IN', { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false });
 }
 
-/* ═══════════════════════════════════════════════════════════════════════
- * State Card Component
- * ═══════════════════════════════════════════════════════════════════════ */
-
-function StateCard({ label, children, accent, warning }: {
+function MiniCard({ label, children, accent, warning }: {
   label: string;
   children: React.ReactNode;
   accent?: boolean;
   warning?: boolean;
 }) {
   return (
-    <div className={`rounded-xl border p-4 transition-all duration-300 ${
-      warning ? 'border-amber-500/20 bg-amber-500/[0.04]' :
-      accent ? 'border-accent/20 bg-accent/[0.04]' :
-      'border-surface-border bg-surface-raised'
+    <div className={`rounded-lg border px-3 py-2.5 transition-all duration-200 ${
+      warning ? 'border-amber-500/15 bg-amber-500/[0.03]' :
+      accent ? 'border-accent/15 bg-accent/[0.03]' :
+      'border-surface-border/60 bg-surface-raised/50'
     }`}>
-      <p className="text-[10px] uppercase tracking-wider font-semibold text-text-muted mb-2">{label}</p>
+      <p className="text-[9px] uppercase tracking-wider font-semibold text-text-muted mb-1.5">{label}</p>
       {children}
     </div>
   );
 }
 
-/* ═══════════════════════════════════════════════════════════════════════
- * Data Health Bar
- * ═══════════════════════════════════════════════════════════════════════ */
-
 function DataHealthBar({ live, historical, stale }: { live: number; historical: number; stale: number }) {
   const total = live + historical + stale;
-  if (total === 0) return <span className="text-xs text-text-muted">No scan data</span>;
+  if (total === 0) return <span className="text-[10px] text-text-muted">No data</span>;
   const pLive = (live / total) * 100;
   const pHist = (historical / total) * 100;
   const pStale = (stale / total) * 100;
   return (
     <div>
-      <div className="flex h-2 w-full overflow-hidden rounded-full bg-surface-overlay">
+      <div className="flex h-1.5 w-full overflow-hidden rounded-full bg-surface-overlay">
         {pLive > 0 && <div className="bg-emerald-400 transition-all duration-500" style={{ width: `${pLive}%` }} />}
         {pHist > 0 && <div className="bg-blue-400 transition-all duration-500" style={{ width: `${pHist}%` }} />}
         {pStale > 0 && <div className="bg-amber-400 transition-all duration-500" style={{ width: `${pStale}%` }} />}
       </div>
-      <div className="mt-1.5 flex gap-3 text-[10px] text-text-muted">
-        {live > 0 && <span className="flex items-center gap-1"><span className="h-1.5 w-1.5 rounded-full bg-emerald-400" />{live} live</span>}
-        {historical > 0 && <span className="flex items-center gap-1"><span className="h-1.5 w-1.5 rounded-full bg-blue-400" />{historical} hist</span>}
-        {stale > 0 && <span className="flex items-center gap-1"><span className="h-1.5 w-1.5 rounded-full bg-amber-400" />{stale} stale</span>}
+      <div className="mt-1 flex gap-2 text-[9px] text-text-muted">
+        {live > 0 && <span className="flex items-center gap-1"><span className="h-1 w-1 rounded-full bg-emerald-400" />{live}</span>}
+        {historical > 0 && <span className="flex items-center gap-1"><span className="h-1 w-1 rounded-full bg-blue-400" />{historical}</span>}
+        {stale > 0 && <span className="flex items-center gap-1"><span className="h-1 w-1 rounded-full bg-amber-400" />{stale}</span>}
       </div>
     </div>
   );
 }
-
-/* ═══════════════════════════════════════════════════════════════════════
- * Actor badge
- * ═══════════════════════════════════════════════════════════════════════ */
 
 const ACTOR_STYLES: Record<string, { bg: string; text: string; label: string }> = {
   dad:        { bg: 'bg-blue-500/10',    text: 'text-blue-400',    label: 'Dad' },
@@ -215,10 +191,6 @@ function ActorBadge({ actor }: { actor?: ActivityActor }) {
   );
 }
 
-/* ═══════════════════════════════════════════════════════════════════════
- * Changes pill
- * ═══════════════════════════════════════════════════════════════════════ */
-
 function ChangePills({ changes }: { changes: ActivityChange[] }) {
   return (
     <div className="mt-1.5 flex flex-wrap gap-1.5">
@@ -240,10 +212,6 @@ function ChangePills({ changes }: { changes: ActivityChange[] }) {
   );
 }
 
-/* ═══════════════════════════════════════════════════════════════════════
- * Timeline Entry
- * ═══════════════════════════════════════════════════════════════════════ */
-
 function TimelineEntry({ event, expanded, onToggle, supportMode }: {
   event: ActivityEvent;
   expanded: boolean;
@@ -255,42 +223,38 @@ function TimelineEntry({ event, expanded, onToggle, supportMode }: {
 
   return (
     <div
-      className={`timeline-entry group relative flex gap-3 rounded-lg border px-3.5 py-3 transition-all duration-200 cursor-pointer hover:bg-surface-overlay/30 ${
-        isError ? 'border-amber-500/15 bg-amber-500/[0.02]' : 'border-surface-border/60 bg-surface-raised/50'
+      className={`timeline-entry group relative flex gap-3.5 rounded-xl border px-4 py-3.5 transition-all duration-200 cursor-pointer hover:bg-surface-overlay/30 ${
+        isError ? 'border-amber-500/15 bg-amber-500/[0.02]' : 'border-surface-border/50 bg-surface-raised/40'
       }`}
       onClick={onToggle}
     >
-      {/* Left: icon */}
-      <div className={`flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-lg ${cat.bg} ${cat.text}`}>
+      <div className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg ${cat.bg} ${cat.text}`}>
         <ActionIcon action={event.action} />
       </div>
 
-      {/* Center: content */}
       <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2 mb-0.5 flex-wrap">
+        <div className="flex items-center gap-2 mb-1 flex-wrap">
           <span className={`inline-flex items-center rounded px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wider border ${cat.border} ${cat.bg} ${cat.text}`}>
             {cat.label}
           </span>
           {event.actor && <ActorBadge actor={event.actor} />}
-          <span className="text-[10px] text-text-muted font-mono tabular-nums">
+          <span className="text-[10px] text-text-muted font-mono tabular-nums ml-auto">
             {formatTime(event.ts)}
           </span>
-          <span className="text-[10px] text-text-muted/50">
+          <span className="text-[10px] text-text-muted/40">
             {timeAgo(event.ts)}
           </span>
         </div>
-        <p className="text-xs text-text-primary leading-relaxed">{event.label}</p>
+        <p className="text-[13px] text-text-primary leading-relaxed font-medium">{event.label}</p>
 
-        {/* Inline changes */}
         {event.changes && event.changes.length > 0 && (
           <ChangePills changes={event.changes} />
         )}
 
-        {/* Expandable snapshot + detail */}
         {expanded && (
-          <div className="mt-2 space-y-2">
+          <div className="mt-2.5 space-y-2">
             {event.snapshot && (
-              <div className="rounded-md border border-surface-border bg-surface/60 p-2.5">
+              <div className="rounded-lg border border-surface-border/60 bg-surface/60 p-3">
                 <p className="text-[9px] uppercase tracking-wider text-text-muted font-semibold mb-1.5">System saw</p>
                 <div className="flex flex-wrap gap-x-4 gap-y-1">
                   {Object.entries(event.snapshot).map(([k, v]) => (
@@ -303,7 +267,7 @@ function TimelineEntry({ event, expanded, onToggle, supportMode }: {
               </div>
             )}
             {event.detail && supportMode && (
-              <div className="rounded-md border border-surface-border bg-surface/60 p-2.5">
+              <div className="rounded-lg border border-surface-border/60 bg-surface/60 p-3">
                 <p className="text-[9px] uppercase tracking-wider text-text-muted font-semibold mb-1.5">Raw detail</p>
                 <pre className="text-[10px] text-text-secondary font-mono whitespace-pre-wrap leading-relaxed">
                   {JSON.stringify(event.detail, null, 2)}
@@ -316,10 +280,6 @@ function TimelineEntry({ event, expanded, onToggle, supportMode }: {
     </div>
   );
 }
-
-/* ═══════════════════════════════════════════════════════════════════════
- * Logs Table (Support Mode only)
- * ═══════════════════════════════════════════════════════════════════════ */
 
 const LOG_LEVEL_STYLES: Record<LogLevel, string> = {
   INFO:  'text-blue-400 bg-blue-500/10 border-blue-500/20',
@@ -344,8 +304,8 @@ function LogsTable({ logs, loading }: { logs: LogEntry[]; loading: boolean }) {
   logs.forEach((l) => counts[l.level]++);
 
   return (
-    <div className="rounded-2xl border border-surface-border bg-surface-raised overflow-hidden">
-      <div className="flex flex-col sm:flex-row gap-3 items-start sm:items-center px-5 py-4 border-b border-surface-border">
+    <div className="rounded-xl border border-surface-border/60 bg-surface-raised/50 overflow-hidden">
+      <div className="flex flex-col sm:flex-row gap-3 items-start sm:items-center px-4 py-3 border-b border-surface-border/40">
         <div className="flex gap-1.5 flex-wrap">
           {(['ALL', 'API', 'ERROR', 'WARN', 'INFO', 'DEBUG'] as const).map((lvl) => (
             <button key={lvl} onClick={() => setFilter(lvl)}
@@ -404,10 +364,6 @@ function LogsTable({ logs, loading }: { logs: LogEntry[]; loading: boolean }) {
   );
 }
 
-/* ═══════════════════════════════════════════════════════════════════════
- * Action Flow — visual sequence of user & system actions
- * ═══════════════════════════════════════════════════════════════════════ */
-
 const ACTION_FLOW_COLORS: Record<string, { dot: string; line: string; label: string }> = {
   'scan-manual':       { dot: 'bg-blue-400',    line: 'bg-blue-400/20',    label: 'Manual Scan' },
   'scan-auto':         { dot: 'bg-amber-400',   line: 'bg-amber-400/20',   label: 'Auto Scan' },
@@ -416,161 +372,114 @@ const ACTION_FLOW_COLORS: Record<string, { dot: string; line: string; label: str
   'stock-removed':     { dot: 'bg-red-400',     line: 'bg-red-400/20',     label: 'Removed Stock' },
   'closewatch-on':     { dot: 'bg-amber-400',   line: 'bg-amber-400/20',   label: 'Star On' },
   'closewatch-off':    { dot: 'bg-slate-400',   line: 'bg-slate-400/20',   label: 'Star Off' },
-  'autocheck-started': { dot: 'bg-emerald-400', line: 'bg-emerald-400/20', label: 'Auto-Watch On' },
-  'autocheck-stopped': { dot: 'bg-red-400',     line: 'bg-red-400/20',     label: 'Auto-Watch Off' },
-  'intraday-on':       { dot: 'bg-cyan-400',    line: 'bg-cyan-400/20',    label: 'Intraday On' },
-  'intraday-off':      { dot: 'bg-slate-400',   line: 'bg-slate-400/20',   label: 'Intraday Off' },
-  'nifty50-discovery': { dot: 'bg-blue-400',    line: 'bg-blue-400/20',    label: 'N50 Discovery' },
-  'data-stale':        { dot: 'bg-amber-400',   line: 'bg-amber-400/20',   label: 'Stale Data' },
+  'autocheck-started': { dot: 'bg-emerald-400', line: 'bg-emerald-400/20', label: 'Auto On' },
+  'autocheck-stopped': { dot: 'bg-red-400',     line: 'bg-red-400/20',     label: 'Auto Off' },
+  'intraday-on':       { dot: 'bg-cyan-400',    line: 'bg-cyan-400/20',    label: 'Intra On' },
+  'intraday-off':      { dot: 'bg-slate-400',   line: 'bg-slate-400/20',   label: 'Intra Off' },
+  'nifty50-discovery': { dot: 'bg-blue-400',    line: 'bg-blue-400/20',    label: 'N50' },
+  'data-stale':        { dot: 'bg-amber-400',   line: 'bg-amber-400/20',   label: 'Stale' },
   'scan-error':        { dot: 'bg-red-400',     line: 'bg-red-400/20',     label: 'Error' },
 };
 
-function ActionFlowSection({ events }: { events: ActivityEvent[] }) {
-  // Show the last 20 meaningful actions as a horizontal flow
+function CompactActionFlow({ events }: { events: ActivityEvent[] }) {
   const flowEvents = useMemo(() => {
     return events
       .filter((e) => ACTION_FLOW_COLORS[e.action])
-      .slice(0, 20);
+      .slice(0, 16);
   }, [events]);
 
   if (flowEvents.length === 0) return null;
 
-  // Group consecutive events into "sessions" by time gaps (>10 min = new session)
-  const sessions: { events: ActivityEvent[]; startTime: string; endTime: string }[] = [];
-  let currentSession: ActivityEvent[] = [];
-
-  for (const e of flowEvents) {
-    if (currentSession.length === 0) {
-      currentSession.push(e);
-    } else {
-      const prevTime = new Date(currentSession[currentSession.length - 1].ts).getTime();
-      const curTime = new Date(e.ts).getTime();
-      if (prevTime - curTime > 10 * 60_000) {
-        sessions.push({
-          events: currentSession,
-          startTime: currentSession[currentSession.length - 1].ts,
-          endTime: currentSession[0].ts,
-        });
-        currentSession = [e];
-      } else {
-        currentSession.push(e);
-      }
-    }
-  }
-  if (currentSession.length > 0) {
-    sessions.push({
-      events: currentSession,
-      startTime: currentSession[currentSession.length - 1].ts,
-      endTime: currentSession[0].ts,
-    });
-  }
-
   return (
-    <section>
-      <div className="flex items-center justify-between mb-3">
-        <div className="flex items-center gap-2">
-          <h2 className="text-xs font-bold uppercase tracking-wider text-text-muted">Action Flow</h2>
-          <span className="text-[9px] text-text-muted/50">{flowEvents.length} actions in {sessions.length} session{sessions.length !== 1 ? 's' : ''}</span>
-        </div>
-      </div>
-
-      <div className="rounded-2xl border border-surface-border bg-surface-raised overflow-hidden">
-        <div className="overflow-x-auto scrollbar-thin px-5 py-4">
-          {sessions.map((session, si) => (
-            <div key={si} className="mb-4 last:mb-0">
-              {/* Session header */}
-              <div className="flex items-center gap-2 mb-2">
-                <span className="text-[9px] font-mono text-text-muted/50 tabular-nums">
-                  {formatTime(session.startTime)}
-                </span>
-                <div className="h-px flex-1 bg-surface-border/40" />
-                <span className="text-[9px] font-mono text-text-muted/50 tabular-nums">
-                  {formatTime(session.endTime)}
-                </span>
-                <span className="text-[9px] text-text-muted/30">
-                  ({session.events.length} action{session.events.length !== 1 ? 's' : ''})
-                </span>
+    <div className="flex flex-wrap items-center gap-1 py-1">
+      {flowEvents.map((event, ei) => {
+        const colors = ACTION_FLOW_COLORS[event.action] ?? { dot: 'bg-slate-400', line: 'bg-slate-400/20', label: event.action };
+        const isAlert = event.action === 'alert-fired';
+        return (
+          <div key={event.id} className="flex items-center">
+            {ei > 0 && <div className={`h-px w-2 ${colors.line}`} />}
+            <div className="group relative" title={`${event.label} (${formatTime(event.ts)})`}>
+              <div className={`flex h-5 w-5 items-center justify-center rounded-md border border-surface-border/50 bg-surface-overlay/60 transition-all group-hover:scale-110 ${
+                isAlert ? 'ring-1 ring-accent/25' : ''
+              }`}>
+                <div className={`h-1.5 w-1.5 rounded-full ${colors.dot} ${isAlert ? 'animate-pulse' : ''}`} />
               </div>
-
-              {/* Flow visualization */}
-              <div className="flex items-center gap-0 overflow-x-auto">
-                {session.events.map((event, ei) => {
-                  const colors = ACTION_FLOW_COLORS[event.action] ?? { dot: 'bg-slate-400', line: 'bg-slate-400/20', label: event.action };
-                  const isAlert = event.action === 'alert-fired';
-                  const isError = event.action === 'scan-error' || event.action === 'data-stale';
-
-                  return (
-                    <div key={event.id} className="flex items-center">
-                      {/* Connector line */}
-                      {ei > 0 && (
-                        <div className={`h-0.5 w-6 ${colors.line}`} />
-                      )}
-                      {/* Node */}
-                      <div className="group relative flex flex-col items-center" title={`${event.label} (${formatTime(event.ts)})`}>
-                        <div className={`relative flex h-7 w-7 items-center justify-center rounded-lg border border-surface-border/60 bg-surface-overlay transition-all duration-200 group-hover:scale-110 ${
-                          isAlert ? 'ring-1 ring-accent/30 shadow-[0_0_8px_rgba(0,212,170,0.15)]' :
-                          isError ? 'ring-1 ring-amber-500/30' : ''
-                        }`}>
-                          <div className={`h-2 w-2 rounded-full ${colors.dot} ${isAlert ? 'animate-pulse' : ''}`} />
-                        </div>
-                        <span className="mt-1 text-[7px] font-semibold text-text-muted/50 whitespace-nowrap group-hover:text-text-muted transition-colors">
-                          {colors.label}
-                        </span>
-                        {/* Hover tooltip */}
-                        <div className="absolute bottom-full mb-2 left-1/2 -translate-x-1/2 opacity-0 group-hover:opacity-100 transition-opacity z-20 pointer-events-none">
-                          <div className="rounded-lg border border-surface-border bg-surface-raised px-3 py-2 shadow-xl shadow-black/40 text-[10px] whitespace-nowrap">
-                            <p className="font-semibold text-text-primary">{event.label}</p>
-                            <p className="text-text-muted font-mono tabular-nums">{formatTime(event.ts)} · {timeAgo(event.ts)}</p>
-                            {event.actor && <p className="text-text-muted/60 mt-0.5">by {event.actor}</p>}
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  );
-                })}
+              <div className="absolute bottom-full mb-1.5 left-1/2 -translate-x-1/2 opacity-0 group-hover:opacity-100 transition-opacity z-20 pointer-events-none">
+                <div className="rounded-lg border border-surface-border bg-surface-raised px-2.5 py-1.5 shadow-xl shadow-black/40 text-[9px] whitespace-nowrap">
+                  <p className="font-semibold text-text-primary">{colors.label}</p>
+                  <p className="text-text-muted font-mono tabular-nums">{formatTime(event.ts)}</p>
+                </div>
               </div>
             </div>
-          ))}
-        </div>
-
-        {/* Flow legend */}
-        <div className="flex items-center gap-3 border-t border-surface-border px-5 py-2 flex-wrap">
-          {Object.entries(ACTION_FLOW_COLORS).slice(0, 8).map(([action, colors]) => (
-            <span key={action} className="flex items-center gap-1 text-[8px] text-text-muted/50">
-              <span className={`h-1.5 w-1.5 rounded-full ${colors.dot}`} />
-              {colors.label}
-            </span>
-          ))}
-        </div>
-      </div>
-    </section>
+          </div>
+        );
+      })}
+    </div>
   );
 }
 
-/* ═══════════════════════════════════════════════════════════════════════
- * Main Dev Dashboard
- * ═══════════════════════════════════════════════════════════════════════ */
+function CollapsibleSection({ title, icon, badge, badgeColor, defaultOpen, children }: {
+  title: string;
+  icon: React.ReactNode;
+  badge?: string;
+  badgeColor?: string;
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(defaultOpen ?? false);
+  return (
+    <div className="rounded-xl border border-surface-border/50 bg-surface-raised/30 overflow-hidden">
+      <button
+        onClick={() => setOpen(!open)}
+        className="flex items-center gap-2.5 w-full px-3.5 py-2.5 text-left transition-colors hover:bg-surface-overlay/20"
+      >
+        <span className="text-text-muted">{icon}</span>
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-text-muted flex-1">{title}</span>
+        {badge && (
+          <span className={`text-[9px] font-bold px-1.5 py-0.5 rounded ${badgeColor || 'bg-surface-overlay text-text-muted'}`}>
+            {badge}
+          </span>
+        )}
+        <svg
+          width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"
+          className={`text-text-muted/50 transition-transform duration-200 ${open ? 'rotate-180' : ''}`}
+        >
+          <polyline points="6 9 12 15 18 9" />
+        </svg>
+      </button>
+      {open && (
+        <div className="px-3.5 pb-3 border-t border-surface-border/30">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const GRID_BG_STYLE: React.CSSProperties = {
+  backgroundImage: `url("data:image/svg+xml,%3Csvg width='40' height='40' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M0 0h40v40' fill='none' stroke='%23f0f2f7' stroke-opacity='0.035' stroke-width='0.5'/%3E%3C/svg%3E")`,
+  backgroundSize: '40px 40px',
+  maskImage: 'radial-gradient(ellipse 80% 70% at 50% 30%, rgba(0,0,0,0.6) 0%, rgba(0,0,0,0.2) 50%, transparent 80%)',
+  WebkitMaskImage: 'radial-gradient(ellipse 80% 70% at 50% 30%, rgba(0,0,0,0.6) 0%, rgba(0,0,0,0.2) 50%, transparent 80%)',
+};
 
 export default function DevDashboard() {
-  // Data
   const [state, setState] = useState<SystemState | null>(null);
   const [events, setEvents] = useState<ActivityEvent[]>([]);
   const [logs, setLogs] = useState<LogEntry[]>([]);
   const [logsLoading, setLogsLoading] = useState(true);
 
-  // UI
   const [supportMode, setSupportMode] = useState(false);
   const [autoRefresh, setAutoRefresh] = useState(true);
   const [timelineFilter, setTimelineFilter] = useState<TimelineFilter>('all');
   const [expandedEvent, setExpandedEvent] = useState<string | null>(null);
 
-  // Refs for GSAP
   const timelineRef = useRef<HTMLDivElement>(null);
-  const stateCardsRef = useRef<HTMLDivElement>(null);
+  const sidebarRef = useRef<HTMLDivElement>(null);
   const prevEventCountRef = useRef(0);
 
-  // ── Support mode from URL or localStorage ───────────────────────────
   useEffect(() => {
+    if (typeof window === 'undefined') return;
     const params = new URLSearchParams(window.location.search);
     const fromUrl = params.get('support') === 'true' || params.get('support') === '1';
     const fromStorage = localStorage.getItem('nse-support-mode') === '1';
@@ -581,10 +490,10 @@ export default function DevDashboard() {
   }, []);
 
   useEffect(() => {
+    if (typeof window === 'undefined') return;
     localStorage.setItem('nse-support-mode', supportMode ? '1' : '0');
   }, [supportMode]);
 
-  // ── Data fetching ───────────────────────────────────────────────────
   const fetchAll = useCallback(async () => {
     try {
       const [stateRes, activityRes] = await Promise.all([
@@ -597,9 +506,7 @@ export default function DevDashboard() {
       ]);
       setState(stateData);
       setEvents(activityData.events || []);
-    } catch {
-      // silently fail
-    }
+    } catch { }
   }, []);
 
   const fetchLogs = useCallback(async () => {
@@ -607,7 +514,7 @@ export default function DevDashboard() {
       const res = await fetch('/api/logs?limit=500');
       const data = await res.json();
       if (data.success) setLogs(data.logs);
-    } catch { /* */ }
+    } catch { }
     finally { setLogsLoading(false); }
   }, []);
 
@@ -625,18 +532,16 @@ export default function DevDashboard() {
     return () => clearInterval(interval);
   }, [autoRefresh, fetchAll, fetchLogs, supportMode]);
 
-  // ── GSAP entrance animations ────────────────────────────────────────
   useEffect(() => {
-    if (stateCardsRef.current) {
+    if (sidebarRef.current) {
       gsap.fromTo(
-        stateCardsRef.current.children,
-        { opacity: 0, y: 10 },
-        { opacity: 1, y: 0, duration: 0.35, stagger: 0.06, ease: 'power2.out' }
+        sidebarRef.current.children,
+        { opacity: 0, y: 8 },
+        { opacity: 1, y: 0, duration: 0.3, stagger: 0.05, ease: 'power2.out' }
       );
     }
   }, [state !== null]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Animate new timeline entries
   useEffect(() => {
     if (!timelineRef.current) return;
     const entries = timelineRef.current.querySelectorAll('.timeline-entry');
@@ -651,7 +556,6 @@ export default function DevDashboard() {
     prevEventCountRef.current = newCount;
   }, [events]);
 
-  // ── Filtered events ─────────────────────────────────────────────────
   const filteredEvents = useMemo(() =>
     timelineFilter === 'all' ? events : events.filter((e) => e.cat === timelineFilter),
     [events, timelineFilter]
@@ -663,27 +567,28 @@ export default function DevDashboard() {
     return c;
   }, [events]);
 
-  // ── Scan metadata shortcuts ─────────────────────────────────────────
   const scan = state?.scan;
   const hasStale = (scan?.staleCount ?? 0) > 0;
 
   return (
-    <div className="min-h-screen bg-surface text-text-primary font-body">
-      {/* ── Header ──────────────────────────────────────────────────────── */}
-      <header className="sticky top-0 z-40 bg-surface/80 backdrop-blur-xl border-b border-surface-border">
-        <div className="max-w-[1400px] mx-auto px-6 py-3.5 flex items-center justify-between">
+    <div className="min-h-screen bg-surface text-text-primary font-body relative">
+      <div className="fixed inset-0 pointer-events-none" style={GRID_BG_STYLE} aria-hidden="true" />
+
+      <header className="sticky top-0 z-40 bg-surface/85 backdrop-blur-xl border-b border-surface-border/60">
+        <div className="max-w-[1480px] mx-auto px-6 py-3 flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <div className="w-8 h-8 rounded-lg bg-accent/10 border border-accent/20 flex items-center justify-center text-accent text-sm font-bold">
-              {'</>'}
+            <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-accent/[0.08] ring-1 ring-accent/15">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="text-accent">
+                <polyline points="16 18 22 12 16 6" /><polyline points="8 6 2 12 8 18" />
+              </svg>
             </div>
             <div>
-              <h1 className="text-base font-bold tracking-tight leading-tight">Developer Console</h1>
-              <p className="text-[10px] text-text-muted">Activity timeline · System state · Audit trail</p>
+              <h1 className="font-display text-sm font-bold tracking-tight leading-tight">Dev Console</h1>
+              <p className="text-[9px] text-text-muted font-medium">Activity · State · Audit</p>
             </div>
           </div>
 
           <div className="flex items-center gap-2">
-            {/* Support mode toggle */}
             <button
               onClick={() => setSupportMode(!supportMode)}
               className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-[10px] font-semibold border transition-all duration-200 ${
@@ -691,7 +596,6 @@ export default function DevDashboard() {
                   ? 'bg-violet-500/10 border-violet-500/20 text-violet-400'
                   : 'bg-surface-raised border-surface-border text-text-muted hover:text-text-secondary'
               }`}
-              title="Toggle support mode for debug details"
             >
               <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                 <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />
@@ -699,7 +603,6 @@ export default function DevDashboard() {
               Support
             </button>
 
-            {/* Live toggle */}
             <button
               onClick={() => setAutoRefresh(!autoRefresh)}
               className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-[10px] font-semibold border transition-all duration-200 ${
@@ -713,7 +616,7 @@ export default function DevDashboard() {
             </button>
 
             <button onClick={fetchAll}
-              className="px-2.5 py-1.5 bg-surface-raised hover:bg-surface-overlay border border-surface-border rounded-lg text-[10px] font-semibold transition-colors">
+              className="px-2.5 py-1.5 bg-surface-raised hover:bg-surface-overlay border border-surface-border rounded-lg text-[10px] font-semibold transition-colors text-text-secondary">
               Refresh
             </button>
 
@@ -725,420 +628,369 @@ export default function DevDashboard() {
         </div>
       </header>
 
-      <main className="max-w-[1400px] mx-auto px-6 py-6 space-y-6">
-        {/* ── Current State Panel ───────────────────────────────────────── */}
-        <section>
-          <h2 className="text-xs font-bold uppercase tracking-wider text-text-muted mb-3">Current State</h2>
-          <div ref={stateCardsRef} className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-7 gap-3">
-            {/* Nifty 50 */}
-            <StateCard label="Nifty 50" accent={!!state?.nifty && state.nifty.change >= 0} warning={!!state?.nifty && state.nifty.change < 0}>
-              {state?.nifty ? (
-                <div>
-                  <p className="text-sm font-bold tabular-nums">{state.nifty.value.toLocaleString('en-IN', { maximumFractionDigits: 2 })}</p>
-                  <span className={`inline-flex items-center gap-0.5 mt-0.5 text-[10px] font-semibold tabular-nums ${state.nifty.change >= 0 ? 'text-emerald-400' : 'text-red-400'}`}>
-                    {state.nifty.change >= 0 ? '+' : ''}{state.nifty.change.toFixed(2)} ({state.nifty.changePercent >= 0 ? '+' : ''}{state.nifty.changePercent.toFixed(2)}%)
-                  </span>
-                </div>
-              ) : <span className="text-xs text-text-muted">Loading...</span>}
-            </StateCard>
+      <main className="max-w-[1480px] mx-auto px-6 py-6 relative z-10">
+        <div className="flex gap-6" style={{ minHeight: 'calc(100vh - 140px)' }}>
 
-            {/* Market */}
-            <StateCard label="Market">
-              {state ? (
-                <div className="flex items-center gap-2">
-                  <span className={`h-2.5 w-2.5 rounded-full ${state.market.open ? 'bg-emerald-400 shadow-[0_0_6px_rgba(52,211,153,0.5)]' : 'bg-red-400'}`} />
-                  <span className={`text-sm font-bold ${state.market.open ? 'text-emerald-400' : 'text-red-400'}`}>
-                    {state.market.open ? 'OPEN' : 'CLOSED'}
-                  </span>
-                </div>
-              ) : <span className="text-xs text-text-muted">Loading...</span>}
-            </StateCard>
-
-            {/* Last Scan */}
-            <StateCard label="Last Scan">
-              {scan ? (
-                <div>
-                  <p className="text-sm font-bold tabular-nums">{formatTime(scan.scannedAt)}</p>
-                  <span className={`inline-flex mt-1 px-1.5 py-0.5 rounded text-[9px] font-bold uppercase ${
-                    scan.scanType === 'auto'
-                      ? 'bg-amber-500/10 text-amber-400 border border-amber-500/20'
-                      : 'bg-blue-500/10 text-blue-400 border border-blue-500/20'
-                  }`}>{scan.scanType}</span>
-                </div>
-              ) : <span className="text-xs text-text-muted">No scans yet</span>}
-            </StateCard>
-
-            {/* Close Watch */}
-            <StateCard label="Close Watch" accent={!!state && state.watchlist.closeWatch > 0}>
-              {state ? (
-                <div>
-                  <p className="text-sm font-bold tabular-nums">{state.watchlist.closeWatch} <span className="text-text-muted font-normal">of {state.watchlist.total}</span></p>
-                  {state.watchlist.closeWatch > 0 && (
-                    <p className="mt-1 text-[10px] text-text-muted truncate" title={state.watchlist.closeWatchSymbols.join(', ')}>
-                      {state.watchlist.closeWatchSymbols.join(', ')}
-                    </p>
-                  )}
-                </div>
-              ) : <span className="text-xs text-text-muted">Loading...</span>}
-            </StateCard>
-
-            {/* Data Health */}
-            <StateCard label="Data Health" warning={hasStale}>
-              {scan ? (
-                <DataHealthBar live={scan.liveCount} historical={scan.historicalCount} stale={scan.staleCount} />
-              ) : <span className="text-xs text-text-muted">No scan data</span>}
-            </StateCard>
-
-            {/* Alerts — with source breakdown */}
-            <StateCard label="Alerts" accent={!!state && state.alerts.unread > 0}>
-              {state ? (
-                <div>
-                  <p className="text-sm font-bold tabular-nums">
-                    {state.alerts.unread > 0 ? (
-                      <><span className="text-accent">{state.alerts.unread}</span> <span className="text-text-muted font-normal">unread</span></>
-                    ) : (
-                      <span className="text-text-muted font-normal">0 unread</span>
-                    )}
-                  </p>
-                  <div className="mt-1 flex items-center gap-2 text-[10px] text-text-muted">
-                    <span>{state.alerts.total} total</span>
-                    {(state.alerts.nifty50Alerts ?? 0) > 0 && (
-                      <span className="flex items-center gap-0.5">
-                        <span className="h-1.5 w-1.5 rounded-full bg-blue-400" />
-                        {state.alerts.nifty50Alerts} N50
-                      </span>
-                    )}
-                    {(state.alerts.scanAlerts ?? 0) > 0 && (
-                      <span className="flex items-center gap-0.5">
-                        <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" />
-                        {state.alerts.scanAlerts} scan
-                      </span>
-                    )}
-                  </div>
-                </div>
-              ) : <span className="text-xs text-text-muted">Loading...</span>}
-            </StateCard>
-
-            {/* Cache — with hit rate */}
-            <StateCard label="Cache" accent={!!state?.cacheLayers && state.cacheLayers.apiThrottle.hitRate > 60}>
-              {state ? (
-                <div>
-                  <p className="text-sm font-bold tabular-nums">{state.cache.size} <span className="text-text-muted font-normal">entries</span></p>
-                  {state.cacheLayers && (
-                    <div className="mt-1 flex items-center gap-1">
-                      <div className="h-1.5 w-12 rounded-full bg-surface-overlay overflow-hidden">
-                        <div className="h-full rounded-full bg-emerald-400 transition-all duration-500"
-                          style={{ width: `${state.cacheLayers.apiThrottle.hitRate}%` }} />
-                      </div>
-                      <span className="text-[9px] text-emerald-400 font-semibold tabular-nums">{state.cacheLayers.apiThrottle.hitRate}%</span>
-                      <span className="text-[9px] text-text-muted">hit</span>
-                    </div>
-                  )}
-                  <p className="mt-0.5 text-[10px] text-text-muted">{state.cache.date}</p>
-                </div>
-              ) : <span className="text-xs text-text-muted">Loading...</span>}
-            </StateCard>
-          </div>
-
-          {/* ── Nifty 50 Table Tracking ──────────────────────────────────── */}
-          {state?.nifty50Stats && (() => {
-            const n = state.nifty50Stats;
-            const bl = n.baselines;
-            const fetchOk = n.snapshotFetchSuccess;
-            const totalFetches = n.snapshotFetchCount + n.snapshotFailCount;
-            const successRate = totalFetches > 0 ? Math.round((n.snapshotFetchCount / totalFetches) * 100) : 0;
-            return (
-              <div className={`mt-3 rounded-xl border p-4 ${fetchOk ? 'border-blue-500/20 bg-blue-500/[0.03]' : 'border-amber-500/20 bg-amber-500/[0.04]'}`}>
-                <div className="flex items-center justify-between mb-3">
+          <div className="flex-1 min-w-0" style={{ flexBasis: '62%' }}>
+            {events.length > 0 && (
+              <div className="mb-4 rounded-xl border border-surface-border/50 bg-surface-raised/30 px-4 py-3">
+                <div className="flex items-center justify-between mb-2">
                   <div className="flex items-center gap-2">
-                    <p className="text-[10px] uppercase tracking-wider font-semibold text-text-muted">Nifty 50 Table</p>
-                    <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded ${fetchOk ? 'bg-emerald-500/10 text-emerald-400' : 'bg-amber-500/10 text-amber-400'}`}>
-                      {fetchOk ? 'Healthy' : 'Degraded'}
-                    </span>
+                    <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="text-text-muted">
+                      <circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/>
+                    </svg>
+                    <span className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Action Flow</span>
                   </div>
+                  <span className="text-[9px] text-text-muted/40 font-mono tabular-nums">
+                    {events.filter(e => ACTION_FLOW_COLORS[e.action]).length} actions
+                  </span>
                 </div>
-                <div className="grid grid-cols-4 gap-4">
-                  {/* Last Refresh */}
-                  <div>
-                    <p className="text-[10px] text-text-muted font-semibold mb-1">Last Refresh</p>
-                    <p className="text-sm font-bold tabular-nums">
-                      {n.lastRefreshTime ? formatTime(n.lastRefreshTime) : '—'}
-                    </p>
-                    <p className="text-[9px] text-text-muted/50 mt-0.5">
-                      {n.lastRefreshTime ? timeAgo(n.lastRefreshTime) : 'Never'}
-                    </p>
-                  </div>
-
-                  {/* Snapshot Fetches */}
-                  <div>
-                    <p className="text-[10px] text-text-muted font-semibold mb-1">Snapshot Fetches</p>
-                    <div className="flex items-baseline gap-1">
-                      <span className="text-sm font-bold tabular-nums text-emerald-400">{n.snapshotFetchCount}</span>
-                      <span className="text-[9px] text-text-muted">ok</span>
-                    </div>
-                    <div className="flex items-baseline gap-1 mt-0.5">
-                      <span className="text-sm font-bold tabular-nums text-red-400">{n.snapshotFailCount}</span>
-                      <span className="text-[9px] text-text-muted">fail</span>
-                    </div>
-                    <p className="text-[9px] text-text-muted/50 mt-0.5">{successRate}% success</p>
-                  </div>
-
-                  {/* Baselines */}
-                  <div>
-                    <p className="text-[10px] text-text-muted font-semibold mb-1">Baselines</p>
-                    <div className="flex items-baseline gap-1">
-                      <span className="text-sm font-bold tabular-nums text-emerald-400">{bl.available}</span>
-                      <span className="text-[9px] text-text-muted">ready</span>
-                    </div>
-                    <div className="flex items-baseline gap-1 mt-0.5">
-                      <span className="text-sm font-bold tabular-nums text-text-muted">{bl.missing}</span>
-                      <span className="text-[9px] text-text-muted">pending</span>
-                    </div>
-                    <div className="mt-1.5 h-1.5 w-full rounded-full bg-surface-overlay overflow-hidden">
-                      <div className="h-full rounded-full bg-emerald-400 transition-all duration-500"
-                        style={{ width: `${bl.available + bl.missing > 0 ? (bl.available / (bl.available + bl.missing)) * 100 : 0}%` }} />
-                    </div>
-                  </div>
-
-                  {/* Baseline Date */}
-                  <div>
-                    <p className="text-[10px] text-text-muted font-semibold mb-1">Baseline Date</p>
-                    <p className="text-sm font-bold tabular-nums font-mono">{bl.date}</p>
-                    <p className="text-[9px] text-text-muted/50 mt-0.5">Recomputes daily</p>
-                  </div>
+                <CompactActionFlow events={events} />
+                <div className="flex items-center gap-2 mt-1.5 flex-wrap">
+                  {Object.entries(ACTION_FLOW_COLORS).slice(0, 8).map(([action, colors]) => (
+                    <span key={action} className="flex items-center gap-1 text-[7px] text-text-muted/40">
+                      <span className={`h-1 w-1 rounded-full ${colors.dot}`} />
+                      {colors.label}
+                    </span>
+                  ))}
                 </div>
               </div>
-            );
-          })()}
+            )}
 
-          {/* ── Cache Layers Panel ──────────────────────────────────────── */}
-          {state?.cacheLayers && (() => {
-            const cl = state.cacheLayers;
-            const snTotal = cl.snapshot.snapshotFetchCount + cl.snapshot.snapshotFailCount;
-            const snRate = snTotal > 0 ? Math.round((cl.snapshot.snapshotFetchCount / snTotal) * 100) : 0;
-            return (
-              <div className="mt-3 rounded-xl border border-violet-500/20 bg-violet-500/[0.02] p-4">
-                <div className="flex items-center justify-between mb-3">
-                  <div className="flex items-center gap-2">
-                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="text-violet-400">
-                      <ellipse cx="12" cy="5" rx="9" ry="3" />
-                      <path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3" />
-                      <path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5" />
-                    </svg>
-                    <p className="text-[10px] uppercase tracking-wider font-semibold text-text-muted">Cache Layers</p>
-                  </div>
-                  <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded ${cl.apiThrottle.hitRate >= 50 ? 'bg-emerald-500/10 text-emerald-400' : 'bg-amber-500/10 text-amber-400'}`}>
-                    {cl.apiThrottle.hitRate}% overall hit rate
-                  </span>
+            <div className="flex items-center justify-between mb-4">
+              <div className="flex items-center gap-3">
+                <h2 className="font-display text-sm font-bold tracking-tight text-text-primary">Activity Timeline</h2>
+                <span className="text-[10px] text-text-muted/50 font-mono tabular-nums">{events.length} events</span>
+              </div>
+              <div className="flex gap-1.5">
+                {(['all', 'user', 'system', 'warning'] as const).map((f) => {
+                  const isActive = timelineFilter === f;
+                  const count = catCounts[f];
+                  const label = f === 'all' ? 'All' : CAT_STYLES[f as ActivityCategory].label;
+                  return (
+                    <button key={f} onClick={() => setTimelineFilter(f)}
+                      className={`px-2 py-0.5 rounded text-[10px] font-semibold border transition-all ${
+                        isActive ? 'bg-text-primary text-surface border-text-primary' : 'bg-surface-raised text-text-muted border-surface-border/60 hover:text-text-secondary'
+                      }`}>
+                      {label} <span className="opacity-50">{count}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div ref={timelineRef} className="space-y-2 overflow-y-auto pr-1 scrollbar-thin" style={{ maxHeight: 'calc(100vh - 200px)' }}>
+              {filteredEvents.length === 0 ? (
+                <div className="rounded-xl border border-surface-border/50 bg-surface-raised/30 px-6 py-16 text-center">
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="mx-auto mb-3 text-text-muted/30">
+                    <circle cx="12" cy="12" r="10" /><path d="M12 6v6l4 2" />
+                  </svg>
+                  <p className="text-xs text-text-muted">No activity recorded yet</p>
+                  <p className="text-[10px] text-text-muted/50 mt-1">Use the main dashboard to trigger events</p>
                 </div>
-                <div className="grid grid-cols-3 gap-4">
-                  {/* Layer 1: Historical Data Cache */}
-                  <div className="rounded-lg border border-surface-border/60 bg-surface-raised/50 p-3">
-                    <div className="flex items-center gap-1.5 mb-2">
-                      <span className="h-2 w-2 rounded-full bg-blue-400" />
-                      <p className="text-[10px] font-semibold text-blue-400">Historical Data</p>
-                    </div>
-                    <p className="text-lg font-bold tabular-nums">{cl.historical.size}</p>
-                    <p className="text-[9px] text-text-muted mt-0.5">symbols cached</p>
-                    <p className="text-[9px] text-text-muted/50 mt-0.5">Date: {cl.historical.date}</p>
-                    {cl.historical.symbols.length > 0 && (
-                      <p className="text-[8px] text-text-muted/40 mt-1 truncate" title={cl.historical.symbols.join(', ')}>
-                        {cl.historical.symbols.slice(0, 5).join(', ')}{cl.historical.symbols.length > 5 ? ` +${cl.historical.symbols.length - 5}` : ''}
-                      </p>
-                    )}
-                    <p className="text-[8px] text-text-muted/30 mt-1">TTL: IST midnight reset</p>
-                  </div>
+              ) : filteredEvents.map((event) => (
+                <TimelineEntry
+                  key={event.id}
+                  event={event}
+                  expanded={expandedEvent === event.id}
+                  onToggle={() => setExpandedEvent(expandedEvent === event.id ? null : event.id)}
+                  supportMode={supportMode}
+                />
+              ))}
+            </div>
 
-                  {/* Layer 2: Nifty 50 Snapshot Cache */}
-                  <div className="rounded-lg border border-surface-border/60 bg-surface-raised/50 p-3">
-                    <div className="flex items-center gap-1.5 mb-2">
-                      <span className={`h-2 w-2 rounded-full ${cl.snapshot.snapshotFetchSuccess ? 'bg-emerald-400' : 'bg-amber-400'}`} />
-                      <p className="text-[10px] font-semibold text-emerald-400">Snapshot (N50)</p>
-                    </div>
-                    <p className="text-lg font-bold tabular-nums">
-                      {cl.snapshot.snapshotFetchCount}<span className="text-text-muted text-xs font-normal"> fetches</span>
-                    </p>
-                    {cl.snapshot.snapshotFailCount > 0 && (
-                      <p className="text-[10px] text-red-400 mt-0.5">{cl.snapshot.snapshotFailCount} failures</p>
-                    )}
-                    <div className="mt-1.5 h-1 w-full rounded-full bg-surface-overlay overflow-hidden">
-                      <div className="h-full rounded-full bg-emerald-400 transition-all duration-500"
-                        style={{ width: `${snRate}%` }} />
-                    </div>
-                    <p className="text-[8px] text-text-muted/50 mt-0.5">{snRate}% success</p>
-                    <p className="text-[8px] text-text-muted/30 mt-0.5">TTL: 3 min market hrs</p>
-                  </div>
+            {supportMode && (
+              <div className="mt-6">
+                <div className="flex items-center justify-between mb-3">
+                  <h2 className="font-display text-sm font-bold tracking-tight text-violet-400 flex items-center gap-2">
+                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                      <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />
+                    </svg>
+                    Raw Logs
+                  </h2>
+                  <button onClick={async () => { await fetch('/api/logs', { method: 'DELETE' }); setLogs([]); }}
+                    className="px-2 py-1 bg-red-500/[0.08] hover:bg-red-500/15 text-red-400 border border-red-500/20 rounded text-[10px] font-semibold transition-colors">
+                    Clear
+                  </button>
+                </div>
+                <LogsTable logs={logs} loading={logsLoading} />
+              </div>
+            )}
+          </div>
 
-                  {/* Layer 3: API Call Cache (throttle prevention) */}
-                  <div className="rounded-lg border border-surface-border/60 bg-surface-raised/50 p-3">
-                    <div className="flex items-center gap-1.5 mb-2">
-                      <span className={`h-2 w-2 rounded-full ${cl.apiThrottle.hitRate >= 50 ? 'bg-violet-400' : 'bg-amber-400'}`} />
-                      <p className="text-[10px] font-semibold text-violet-400">API Throttle</p>
+          <div ref={sidebarRef} className="space-y-3" style={{ flexBasis: '38%', maxWidth: '420px', minWidth: '320px' }}>
+            <div className="sticky top-[60px] space-y-3 overflow-y-auto scrollbar-thin" style={{ maxHeight: 'calc(100vh - 100px)' }}>
+
+              <div>
+                <p className="text-[9px] uppercase tracking-widest font-semibold text-text-muted/60 mb-2 px-0.5">System Status</p>
+                <div className="grid grid-cols-2 gap-2">
+                  <MiniCard label="Nifty 50" accent={!!state?.nifty && state.nifty.change >= 0} warning={!!state?.nifty && state.nifty.change < 0}>
+                    {state?.nifty ? (
+                      <div>
+                        <p className="text-sm font-bold tabular-nums">{state.nifty.value.toLocaleString('en-IN', { maximumFractionDigits: 2 })}</p>
+                        <span className={`text-[9px] font-semibold tabular-nums ${state.nifty.change >= 0 ? 'text-emerald-400' : 'text-red-400'}`}>
+                          {state.nifty.change >= 0 ? '+' : ''}{state.nifty.change.toFixed(2)} ({state.nifty.changePercent >= 0 ? '+' : ''}{state.nifty.changePercent.toFixed(2)}%)
+                        </span>
+                      </div>
+                    ) : <span className="text-[10px] text-text-muted">...</span>}
+                  </MiniCard>
+
+                  <MiniCard label="Market">
+                    {state ? (
+                      <div className="flex items-center gap-2">
+                        <span className={`h-2 w-2 rounded-full ${state.market.open ? 'bg-emerald-400 shadow-[0_0_6px_rgba(52,211,153,0.5)]' : 'bg-red-400'}`} />
+                        <span className={`text-sm font-bold ${state.market.open ? 'text-emerald-400' : 'text-red-400'}`}>
+                          {state.market.open ? 'OPEN' : 'CLOSED'}
+                        </span>
+                      </div>
+                    ) : <span className="text-[10px] text-text-muted">...</span>}
+                  </MiniCard>
+
+                  <MiniCard label="Last Scan">
+                    {scan ? (
+                      <div>
+                        <p className="text-sm font-bold tabular-nums">{formatTime(scan.scannedAt)}</p>
+                        <span className={`inline-flex mt-0.5 px-1 py-px rounded text-[8px] font-bold uppercase ${
+                          scan.scanType === 'auto'
+                            ? 'bg-amber-500/10 text-amber-400'
+                            : 'bg-blue-500/10 text-blue-400'
+                        }`}>{scan.scanType}</span>
+                      </div>
+                    ) : <span className="text-[10px] text-text-muted">None</span>}
+                  </MiniCard>
+
+                  <MiniCard label="Close Watch" accent={!!state && state.watchlist.closeWatch > 0}>
+                    {state ? (
+                      <div>
+                        <p className="text-sm font-bold tabular-nums">{state.watchlist.closeWatch} <span className="text-text-muted text-[10px] font-normal">/ {state.watchlist.total}</span></p>
+                        {state.watchlist.closeWatch > 0 && (
+                          <p className="mt-0.5 text-[9px] text-text-muted truncate" title={state.watchlist.closeWatchSymbols.join(', ')}>
+                            {state.watchlist.closeWatchSymbols.join(', ')}
+                          </p>
+                        )}
+                      </div>
+                    ) : <span className="text-[10px] text-text-muted">...</span>}
+                  </MiniCard>
+
+                  <MiniCard label="Data Health" warning={hasStale}>
+                    {scan ? (
+                      <DataHealthBar live={scan.liveCount} historical={scan.historicalCount} stale={scan.staleCount} />
+                    ) : <span className="text-[10px] text-text-muted">No data</span>}
+                  </MiniCard>
+
+                  <MiniCard label="Alerts" accent={!!state && state.alerts.unread > 0}>
+                    {state ? (
+                      <div>
+                        <p className="text-sm font-bold tabular-nums">
+                          {state.alerts.unread > 0 ? (
+                            <><span className="text-accent">{state.alerts.unread}</span> <span className="text-text-muted text-[10px] font-normal">unread</span></>
+                          ) : (
+                            <span className="text-text-muted text-[10px] font-normal">0 unread</span>
+                          )}
+                        </p>
+                        <div className="mt-0.5 flex items-center gap-2 text-[9px] text-text-muted">
+                          <span>{state.alerts.total} total</span>
+                          {(state.alerts.nifty50Alerts ?? 0) > 0 && (
+                            <span className="flex items-center gap-0.5">
+                              <span className="h-1 w-1 rounded-full bg-blue-400" />{state.alerts.nifty50Alerts}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                    ) : <span className="text-[10px] text-text-muted">...</span>}
+                  </MiniCard>
+
+                  <MiniCard label="Cache" accent={!!state?.cacheLayers && state.cacheLayers.apiThrottle.hitRate > 60}>
+                    {state ? (
+                      <div>
+                        <p className="text-sm font-bold tabular-nums">{state.cache.size} <span className="text-text-muted text-[10px] font-normal">entries</span></p>
+                        {state.cacheLayers && (
+                          <div className="mt-0.5 flex items-center gap-1">
+                            <div className="h-1 w-10 rounded-full bg-surface-overlay overflow-hidden">
+                              <div className="h-full rounded-full bg-emerald-400 transition-all duration-500"
+                                style={{ width: `${state.cacheLayers.apiThrottle.hitRate}%` }} />
+                            </div>
+                            <span className="text-[8px] text-emerald-400 font-semibold tabular-nums">{state.cacheLayers.apiThrottle.hitRate}%</span>
+                          </div>
+                        )}
+                      </div>
+                    ) : <span className="text-[10px] text-text-muted">...</span>}
+                  </MiniCard>
+                </div>
+              </div>
+
+              {state?.nifty50Stats && (() => {
+                const n = state.nifty50Stats;
+                const bl = n.baselines;
+                const fetchOk = n.snapshotFetchSuccess;
+                const totalFetches = n.snapshotFetchCount + n.snapshotFailCount;
+                const successRate = totalFetches > 0 ? Math.round((n.snapshotFetchCount / totalFetches) * 100) : 0;
+                return (
+                  <CollapsibleSection
+                    title="Nifty 50 Table"
+                    icon={<svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>}
+                    badge={fetchOk ? 'Healthy' : 'Degraded'}
+                    badgeColor={fetchOk ? 'bg-emerald-500/10 text-emerald-400' : 'bg-amber-500/10 text-amber-400'}
+                  >
+                    <div className="grid grid-cols-2 gap-3 pt-2.5">
+                      <div>
+                        <p className="text-[9px] text-text-muted font-semibold mb-1">Last Refresh</p>
+                        <p className="text-xs font-bold tabular-nums">{n.lastRefreshTime ? formatTime(n.lastRefreshTime) : '—'}</p>
+                        <p className="text-[8px] text-text-muted/40 mt-0.5">{n.lastRefreshTime ? timeAgo(n.lastRefreshTime) : 'Never'}</p>
+                      </div>
+                      <div>
+                        <p className="text-[9px] text-text-muted font-semibold mb-1">Fetches</p>
+                        <div className="flex items-baseline gap-1.5">
+                          <span className="text-xs font-bold tabular-nums text-emerald-400">{n.snapshotFetchCount}</span>
+                          <span className="text-[8px] text-text-muted">ok</span>
+                          <span className="text-xs font-bold tabular-nums text-red-400">{n.snapshotFailCount}</span>
+                          <span className="text-[8px] text-text-muted">fail</span>
+                        </div>
+                        <p className="text-[8px] text-text-muted/40 mt-0.5">{successRate}% success</p>
+                      </div>
+                      <div>
+                        <p className="text-[9px] text-text-muted font-semibold mb-1">Baselines</p>
+                        <div className="flex items-baseline gap-1.5">
+                          <span className="text-xs font-bold tabular-nums text-emerald-400">{bl.available}</span>
+                          <span className="text-[8px] text-text-muted">ready</span>
+                          <span className="text-xs font-bold tabular-nums text-text-muted">{bl.missing}</span>
+                          <span className="text-[8px] text-text-muted">pending</span>
+                        </div>
+                        <div className="mt-1 h-1 w-full rounded-full bg-surface-overlay overflow-hidden">
+                          <div className="h-full rounded-full bg-emerald-400 transition-all duration-500"
+                            style={{ width: `${bl.available + bl.missing > 0 ? (bl.available / (bl.available + bl.missing)) * 100 : 0}%` }} />
+                        </div>
+                      </div>
+                      <div>
+                        <p className="text-[9px] text-text-muted font-semibold mb-1">Date</p>
+                        <p className="text-xs font-bold tabular-nums font-mono">{bl.date}</p>
+                        <p className="text-[8px] text-text-muted/40 mt-0.5">Recomputes daily</p>
+                      </div>
                     </div>
-                    <div className="flex items-baseline gap-1">
-                      <span className="text-lg font-bold tabular-nums text-cyan-400">{cl.apiThrottle.apiCalls}</span>
-                      <span className="text-[9px] text-text-muted">API</span>
-                      <span className="text-lg font-bold tabular-nums text-emerald-400 ml-1">{cl.apiThrottle.cacheHits}</span>
-                      <span className="text-[9px] text-text-muted">cache</span>
+                  </CollapsibleSection>
+                );
+              })()}
+
+              {state?.cacheLayers && (() => {
+                const cl = state.cacheLayers;
+                const snTotal = cl.snapshot.snapshotFetchCount + cl.snapshot.snapshotFailCount;
+                const snRate = snTotal > 0 ? Math.round((cl.snapshot.snapshotFetchCount / snTotal) * 100) : 0;
+                return (
+                  <CollapsibleSection
+                    title="Cache Layers"
+                    icon={<svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/></svg>}
+                    badge={`${cl.apiThrottle.hitRate}% hit`}
+                    badgeColor={cl.apiThrottle.hitRate >= 50 ? 'bg-emerald-500/10 text-emerald-400' : 'bg-amber-500/10 text-amber-400'}
+                  >
+                    <div className="space-y-2.5 pt-2.5">
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-1.5">
+                          <span className="h-1.5 w-1.5 rounded-full bg-blue-400" />
+                          <span className="text-[10px] font-semibold text-blue-400">Historical</span>
+                        </div>
+                        <span className="text-xs font-bold tabular-nums">{cl.historical.size} <span className="text-text-muted text-[9px] font-normal">symbols</span></span>
+                      </div>
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-1.5">
+                          <span className={`h-1.5 w-1.5 rounded-full ${cl.snapshot.snapshotFetchSuccess ? 'bg-emerald-400' : 'bg-amber-400'}`} />
+                          <span className="text-[10px] font-semibold text-emerald-400">Snapshot</span>
+                        </div>
+                        <div className="flex items-baseline gap-1.5">
+                          <span className="text-xs font-bold tabular-nums">{cl.snapshot.snapshotFetchCount}</span>
+                          <span className="text-[9px] text-text-muted">fetches</span>
+                          {cl.snapshot.snapshotFailCount > 0 && (
+                            <span className="text-[9px] text-red-400">{cl.snapshot.snapshotFailCount} fail</span>
+                          )}
+                        </div>
+                      </div>
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-1.5">
+                          <span className={`h-1.5 w-1.5 rounded-full ${cl.apiThrottle.hitRate >= 50 ? 'bg-violet-400' : 'bg-amber-400'}`} />
+                          <span className="text-[10px] font-semibold text-violet-400">API Throttle</span>
+                        </div>
+                        <div className="flex items-baseline gap-1.5">
+                          <span className="text-xs font-bold tabular-nums text-cyan-400">{cl.apiThrottle.apiCalls}</span>
+                          <span className="text-[9px] text-text-muted">api</span>
+                          <span className="text-xs font-bold tabular-nums text-emerald-400">{cl.apiThrottle.cacheHits}</span>
+                          <span className="text-[9px] text-text-muted">cache</span>
+                        </div>
+                      </div>
+                      <div className="h-1 w-full rounded-full bg-surface-overlay overflow-hidden flex">
+                        {cl.apiThrottle.total > 0 && (
+                          <>
+                            <div className="h-full bg-cyan-400 transition-all duration-500"
+                              style={{ width: `${((cl.apiThrottle.apiCalls / cl.apiThrottle.total) * 100)}%` }} />
+                            <div className="h-full bg-emerald-400 transition-all duration-500"
+                              style={{ width: `${((cl.apiThrottle.cacheHits / cl.apiThrottle.total) * 100)}%` }} />
+                          </>
+                        )}
+                      </div>
+                      <p className="text-[8px] text-text-muted/40">{cl.apiThrottle.total} total · {cl.historical.date} · TTL: midnight IST</p>
                     </div>
-                    <div className="mt-1.5 h-1 w-full rounded-full bg-surface-overlay overflow-hidden flex">
-                      {cl.apiThrottle.total > 0 && (
-                        <>
-                          <div className="h-full bg-cyan-400 transition-all duration-500"
-                            style={{ width: `${((cl.apiThrottle.apiCalls / cl.apiThrottle.total) * 100)}%` }} />
-                          <div className="h-full bg-emerald-400 transition-all duration-500"
-                            style={{ width: `${((cl.apiThrottle.cacheHits / cl.apiThrottle.total) * 100)}%` }} />
-                        </>
+                  </CollapsibleSection>
+                );
+              })()}
+
+              {state?.apiStats && (() => {
+                const s = state.apiStats;
+                const total = s.apiCalls + s.cacheHits;
+                const cachePercent = total > 0 ? ((s.cacheHits / total) * 100) : 0;
+                const rateOk = s.recentRate <= 3;
+                const recentApiCalls = s.last60s.filter((r) => r.type === 'api');
+                return (
+                  <CollapsibleSection
+                    title="API Rate"
+                    icon={<svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg>}
+                    badge={`${s.recentRate}/s ${rateOk ? 'OK' : 'HIGH'}`}
+                    badgeColor={rateOk ? 'bg-emerald-500/10 text-emerald-400' : 'bg-amber-500/10 text-amber-400'}
+                  >
+                    <div className="space-y-2.5 pt-2.5">
+                      <div className="flex items-center justify-between">
+                        <span className="text-[10px] text-text-muted">Rate (60s)</span>
+                        <div className="flex items-center gap-2">
+                          <div className="h-1 w-16 rounded-full bg-surface-overlay overflow-hidden">
+                            <div className={`h-full rounded-full transition-all duration-500 ${s.recentRate <= 1 ? 'bg-emerald-400' : s.recentRate <= 2 ? 'bg-blue-400' : s.recentRate <= 3 ? 'bg-amber-400' : 'bg-red-400'}`}
+                              style={{ width: `${Math.min((s.recentRate / 3) * 100, 100)}%` }} />
+                          </div>
+                          <span className="text-xs font-bold tabular-nums">{s.recentRate}<span className="text-[9px] text-text-muted font-normal">/s</span></span>
+                        </div>
+                      </div>
+                      <div className="flex items-center justify-between">
+                        <span className="text-[10px] text-text-muted">API / Cache</span>
+                        <div className="flex items-baseline gap-1.5">
+                          <span className="text-xs font-bold tabular-nums text-cyan-400">{s.apiCalls}</span>
+                          <span className="text-[9px] text-text-muted">/</span>
+                          <span className="text-xs font-bold tabular-nums text-emerald-400">{s.cacheHits}</span>
+                          <span className="text-[9px] text-text-muted">({cachePercent.toFixed(0)}%)</span>
+                        </div>
+                      </div>
+                      {recentApiCalls.length > 0 && (
+                        <div>
+                          <p className="text-[9px] text-text-muted/50 mb-1">Recent calls</p>
+                          <div className="space-y-0.5 max-h-[48px] overflow-y-auto scrollbar-thin">
+                            {recentApiCalls.slice(-4).reverse().map((r, i) => (
+                              <div key={i} className="flex items-center gap-1 text-[9px]">
+                                <span className="w-1 h-1 rounded-full bg-cyan-400 flex-shrink-0" />
+                                <span className="text-text-secondary font-mono truncate">{r.method}{r.symbol ? ` (${r.symbol})` : ''}</span>
+                              </div>
+                            ))}
+                          </div>
+                        </div>
                       )}
                     </div>
-                    <p className="text-[8px] text-text-muted/50 mt-0.5">{cl.apiThrottle.total} total calls tracked</p>
-                    <p className="text-[8px] text-text-muted/30 mt-0.5">Rolling 500 call window</p>
-                  </div>
-                </div>
-              </div>
-            );
-          })()}
-
-          {/* ── API Throttle KPI ────────────────────────────────────────── */}
-          {state?.apiStats && (() => {
-            const s = state.apiStats;
-            const total = s.apiCalls + s.cacheHits;
-            const cachePercent = total > 0 ? ((s.cacheHits / total) * 100) : 0;
-            const rateOk = s.recentRate <= 3;
-            const recentApiCalls = s.last60s.filter((r) => r.type === 'api');
-            const recentCacheHits = s.last60s.filter((r) => r.type === 'cache');
-            return (
-              <div className={`mt-3 rounded-xl border p-4 ${rateOk ? 'border-surface-border bg-surface-raised' : 'border-amber-500/20 bg-amber-500/[0.04]'}`}>
-                <div className="flex items-center justify-between mb-3">
-                  <p className="text-[10px] uppercase tracking-wider font-semibold text-text-muted">API Throttle</p>
-                  <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded ${rateOk ? 'bg-emerald-500/10 text-emerald-400' : 'bg-amber-500/10 text-amber-400'}`}>
-                    {s.recentRate} req/s {rateOk ? '(OK)' : '(HIGH)'}
-                  </span>
-                </div>
-                <div className="grid grid-cols-4 gap-4">
-                  {/* Rate gauge */}
-                  <div>
-                    <p className="text-lg font-bold tabular-nums">{s.recentRate}<span className="text-text-muted text-xs font-normal">/s</span></p>
-                    <p className="text-[10px] text-text-muted mt-0.5">Last 60s rate</p>
-                    <div className="mt-1.5 h-1.5 w-full rounded-full bg-surface-overlay overflow-hidden">
-                      <div className={`h-full rounded-full transition-all duration-500 ${s.recentRate <= 1 ? 'bg-emerald-400' : s.recentRate <= 2 ? 'bg-blue-400' : s.recentRate <= 3 ? 'bg-amber-400' : 'bg-red-400'}`}
-                        style={{ width: `${Math.min((s.recentRate / 3) * 100, 100)}%` }} />
-                    </div>
-                    <p className="text-[9px] text-text-muted/50 mt-0.5">Best practice: &le;3/s</p>
-                  </div>
-
-                  {/* API vs Cache split */}
-                  <div>
-                    <div className="flex items-baseline gap-1">
-                      <span className="text-lg font-bold tabular-nums text-cyan-400">{s.apiCalls}</span>
-                      <span className="text-[10px] text-text-muted">API</span>
-                    </div>
-                    <div className="flex items-baseline gap-1 mt-0.5">
-                      <span className="text-lg font-bold tabular-nums text-emerald-400">{s.cacheHits}</span>
-                      <span className="text-[10px] text-text-muted">Cache</span>
-                    </div>
-                    <p className="text-[10px] text-text-muted mt-1">{cachePercent.toFixed(0)}% hit rate</p>
-                  </div>
-
-                  {/* Last 60s breakdown */}
-                  <div>
-                    <p className="text-[10px] text-text-muted font-semibold mb-1.5">Last 60s</p>
-                    <div className="flex items-baseline gap-1">
-                      <span className="text-sm font-bold tabular-nums text-cyan-400">{recentApiCalls.length}</span>
-                      <span className="text-[9px] text-text-muted">NSE calls</span>
-                    </div>
-                    <div className="flex items-baseline gap-1 mt-0.5">
-                      <span className="text-sm font-bold tabular-nums text-emerald-400">{recentCacheHits.length}</span>
-                      <span className="text-[9px] text-text-muted">cache hits</span>
-                    </div>
-                  </div>
-
-                  {/* Recent API methods */}
-                  <div>
-                    <p className="text-[10px] text-text-muted font-semibold mb-1.5">Recent API calls</p>
-                    <div className="space-y-0.5 max-h-[60px] overflow-y-auto scrollbar-thin">
-                      {recentApiCalls.length === 0 ? (
-                        <span className="text-[10px] text-text-muted/50">None in last 60s</span>
-                      ) : recentApiCalls.slice(-6).reverse().map((r, i) => (
-                        <div key={i} className="flex items-center gap-1.5 text-[9px]">
-                          <span className="w-1 h-1 rounded-full bg-cyan-400 flex-shrink-0" />
-                          <span className="text-text-secondary font-mono truncate">{r.method}{r.symbol ? ` (${r.symbol})` : ''}</span>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                </div>
-              </div>
-            );
-          })()}
-        </section>
-
-        {/* ── User Action Flow ──────────────────────────────────────────── */}
-        <ActionFlowSection events={events} />
-
-        {/* ── Activity Timeline ─────────────────────────────────────────── */}
-        <section>
-          <div className="flex items-center justify-between mb-3">
-            <h2 className="text-xs font-bold uppercase tracking-wider text-text-muted">Activity Timeline</h2>
-            <div className="flex gap-1.5">
-              {(['all', 'user', 'system', 'warning'] as const).map((f) => {
-                const isActive = timelineFilter === f;
-                const count = catCounts[f];
-                const label = f === 'all' ? 'All' : CAT_STYLES[f as ActivityCategory].label;
-                return (
-                  <button key={f} onClick={() => setTimelineFilter(f)}
-                    className={`px-2 py-0.5 rounded text-[10px] font-semibold border transition-all ${
-                      isActive ? 'bg-text-primary text-surface border-text-primary' : 'bg-surface-raised text-text-muted border-surface-border hover:text-text-secondary'
-                    }`}>
-                    {label} <span className="opacity-50">{count}</span>
-                  </button>
+                  </CollapsibleSection>
                 );
-              })}
+              })()}
+
+
             </div>
           </div>
 
-          <div ref={timelineRef} className="space-y-1.5 max-h-[600px] overflow-y-auto pr-1 scrollbar-thin">
-            {filteredEvents.length === 0 ? (
-              <div className="rounded-xl border border-surface-border bg-surface-raised px-6 py-12 text-center">
-                <p className="text-xs text-text-muted">No activity recorded yet. Use the main dashboard to trigger some events.</p>
-              </div>
-            ) : filteredEvents.map((event) => (
-              <TimelineEntry
-                key={event.id}
-                event={event}
-                expanded={expandedEvent === event.id}
-                onToggle={() => setExpandedEvent(expandedEvent === event.id ? null : event.id)}
-                supportMode={supportMode}
-              />
-            ))}
-          </div>
-        </section>
+        </div>
 
-        {/* ── Support Mode: Raw Logs ────────────────────────────────────── */}
-        {supportMode && (
-          <section>
-            <div className="flex items-center justify-between mb-3">
-              <h2 className="text-xs font-bold uppercase tracking-wider text-violet-400">
-                <span className="inline-flex items-center gap-1.5">
-                  <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                    <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />
-                  </svg>
-                  Raw Logs (Support Mode)
-                </span>
-              </h2>
-              <button onClick={async () => { await fetch('/api/logs', { method: 'DELETE' }); setLogs([]); }}
-                className="px-2 py-1 bg-red-500/8 hover:bg-red-500/15 text-red-400 border border-red-500/20 rounded text-[10px] font-semibold transition-colors">
-                Clear
-              </button>
-            </div>
-            <LogsTable logs={logs} loading={logsLoading} />
-          </section>
-        )}
-
-        {/* ── Footer ────────────────────────────────────────────────────── */}
-        <div className="flex items-center justify-between pt-2 pb-4 text-[10px] text-text-muted/40">
+        <div className="flex items-center justify-between pt-4 pb-2 text-[10px] text-text-muted/30 border-t border-surface-border/20 mt-6">
           <span>Server: {state?.serverTime ? formatTime(state.serverTime) : '...'}</span>
-          <span>{supportMode ? 'Support mode active' : 'Tip: add ?support=true to URL for debug details'}</span>
+          <span>{supportMode ? 'Support mode active' : 'Tip: ?support=true for debug'}</span>
         </div>
       </main>
     </div>

--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -211,8 +211,6 @@ export function Dashboard({
   }, []);
 
   const triggeredCount = results.filter((r) => r.triggered).length;
-  const staleCount = results.filter((r) => r.dataSource === "stale").length;
-  const scannedCount = results.length;
 
   return (
     <div className="min-h-screen">
@@ -234,53 +232,6 @@ export function Dashboard({
           </div>
 
           <div className="dashboard-main">
-            {scannedCount > 0 && (
-              <div className={`mb-8 grid gap-3.5 animate-fade-in ${staleCount > 0 ? "grid-cols-4" : "grid-cols-3"}`}>
-                <StatCard
-                  label="Scanned"
-                  value={scannedCount.toString()}
-                  icon={
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                      <circle cx="11" cy="11" r="8" />
-                      <path d="m21 21-4.35-4.35" />
-                    </svg>
-                  }
-                />
-                <StatCard
-                  label="Breakouts"
-                  value={triggeredCount.toString()}
-                  accent={triggeredCount > 0}
-                  icon={
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                      <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" />
-                    </svg>
-                  }
-                />
-                <StatCard
-                  label="Alerts"
-                  value={alerts.length.toString()}
-                  icon={
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                      <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
-                      <path d="M13.73 21a2 2 0 0 1-3.46 0" />
-                    </svg>
-                  }
-                />
-                {staleCount > 0 && (
-                  <StatCard
-                    label="Stale"
-                    value={staleCount.toString()}
-                    warning
-                    icon={
-                      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                        <path d="M12 9v4M12 17h.01M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
-                      </svg>
-                    }
-                  />
-                )}
-              </div>
-            )}
-
             <TickerPanel
               hasCloseWatchStocks={closeWatchCount > 0}
               scanResults={results}
@@ -449,48 +400,6 @@ export function Dashboard({
         onAdd={addStock}
         currentSymbols={watchlist.map((s) => s.symbol)}
       />
-    </div>
-  );
-}
-
-function StatCard({
-  label,
-  value,
-  icon,
-  accent,
-  warning,
-}: {
-  label: string;
-  value: string;
-  icon: React.ReactNode;
-  accent?: boolean;
-  warning?: boolean;
-}) {
-  return (
-    <div className={`relative overflow-hidden flex items-center gap-3.5 rounded-xl p-4 transition-all duration-300 ring-1 ${
-      warning
-        ? "ring-warn/15 bg-warn/[0.03]"
-        : accent
-          ? "ring-accent/15 bg-accent/[0.03]"
-          : "ring-surface-border/50 bg-surface-raised"
-    } card-elevated`}>
-      <div className={`flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg ${
-        warning
-          ? "bg-warn/10 text-warn"
-          : accent
-            ? "bg-accent/10 text-accent"
-            : "bg-surface-overlay text-text-muted"
-      }`}>
-        {icon}
-      </div>
-      <div>
-        <p className={`font-display text-xl font-bold tabular-nums tracking-tight ${
-          warning ? "text-warn" : accent ? "text-accent" : ""
-        }`}>
-          {value}
-        </p>
-        <p className="text-[9px] font-semibold uppercase tracking-[0.1em] text-text-muted">{label}</p>
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
- Restructure dev dashboard into two-column layout: activity timeline (62%) as hero, condensed sidebar (38%)
- Add CSS-only SVG grid background pattern with radial mask-image fade
- Condense 7 state cards into dense 2-column mini-grid in sidebar
- Convert Nifty50 stats, cache layers, API throttle into collapsible sections
- Move action flow above timeline for quick reference
- Remove stat cards bar from user dashboard
- Sticky sidebar with independent scroll