### PR TITLE
Add retry logic for NSE API calls and persist scan results

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,20 @@
 import { Dashboard } from "@/components/dashboard";
-import { getWatchlist, getAlerts } from "@/lib/store";
+import { getWatchlist, getAlerts, getScanResults } from "@/lib/store";
 
 export const dynamic = "force-dynamic";
 
 export default async function Home() {
-  const [watchlist, alerts] = await Promise.all([
+  const [watchlist, alerts, scanResults] = await Promise.all([
     getWatchlist(),
     getAlerts(),
+    getScanResults(),
   ]);
 
-  return <Dashboard initialWatchlist={watchlist} initialAlerts={alerts} />;
+  return (
+    <Dashboard
+      initialWatchlist={watchlist}
+      initialAlerts={alerts}
+      initialResults={scanResults}
+    />
+  );
 }

--- a/src/components/alert-panel.tsx
+++ b/src/components/alert-panel.tsx
@@ -2,11 +2,19 @@
 
 import type { Alert } from "@/lib/types";
 
+function getTodayIST(): string {
+  return new Date(
+    new Date().toLocaleString("en-US", { timeZone: "Asia/Kolkata" })
+  )
+    .toISOString()
+    .slice(0, 10);
+}
+
 export function AlertPanel({ alerts }: { alerts: Alert[] }) {
-  const recentAlerts = alerts.filter((a) => {
-    const age = Date.now() - new Date(a.triggeredAt).getTime();
-    return age < 7 * 24 * 60 * 60 * 1000;
-  });
+  const today = getTodayIST();
+  const recentAlerts = alerts.filter(
+    (a) => a.triggeredAt.slice(0, 10) === today
+  );
 
   const unreadCount = recentAlerts.filter((a) => !a.read).length;
 
@@ -59,7 +67,7 @@ export function AlertPanel({ alerts }: { alerts: Alert[] }) {
       {recentAlerts.length > 0 && (
         <div className="border-t border-surface-border/30 px-4 py-2.5">
           <p className="text-[10px] text-text-muted text-center">
-            {recentAlerts.length} alert{recentAlerts.length !== 1 ? "s" : ""} in last 7 days
+            {recentAlerts.length} alert{recentAlerts.length !== 1 ? "s" : ""} today
           </p>
         </div>
       )}

--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -14,15 +14,17 @@ import type { WatchlistStock, ScanResult, Alert } from "@/lib/types";
 export function Dashboard({
   initialWatchlist,
   initialAlerts,
+  initialResults = [],
 }: {
   initialWatchlist: WatchlistStock[];
   initialAlerts: Alert[];
+  initialResults?: ScanResult[];
 }) {
   const [watchlist, setWatchlist] = useState(initialWatchlist);
-  const [results, setResults] = useState<ScanResult[]>([]);
+  const [results, setResults] = useState<ScanResult[]>(initialResults);
   const [alerts, setAlerts] = useState<Alert[]>(initialAlerts);
   const [scanning, setScanning] = useState(false);
-  const [intraday, setIntraday] = useState(false);
+  const [intraday, setIntraday] = useState(() => isMarketHours());
   const [modalOpen, setModalOpen] = useState(false);
   const [marketOpen, setMarketOpen] = useState(false);
   const [lastScan, setLastScan] = useState<string | null>(null);

--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -1,7 +1,15 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useMemo } from "react";
 import type { Alert } from "@/lib/types";
+
+function getTodayIST(): string {
+  return new Date(
+    new Date().toLocaleString("en-US", { timeZone: "Asia/Kolkata" })
+  )
+    .toISOString()
+    .slice(0, 10);
+}
 
 export function NotificationBell({
   alerts,
@@ -14,7 +22,11 @@ export function NotificationBell({
 }) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
-  const unread = alerts.filter((a) => !a.read).length;
+  const todayAlerts = useMemo(() => {
+    const today = getTodayIST();
+    return alerts.filter((a) => a.triggeredAt.slice(0, 10) === today);
+  }, [alerts]);
+  const unread = todayAlerts.filter((a) => !a.read).length;
 
   useEffect(() => {
     function handleClick(e: MouseEvent) {
@@ -71,7 +83,7 @@ export function NotificationBell({
             )}
           </div>
           <div className="max-h-80 overflow-y-auto scrollbar-thin">
-            {alerts.length === 0 ? (
+            {todayAlerts.length === 0 ? (
               <div className="px-4 py-10 text-center">
                 <div className="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-xl bg-surface-overlay ring-1 ring-surface-border/50">
                   <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="text-text-muted">
@@ -79,11 +91,11 @@ export function NotificationBell({
                     <path d="M13.73 21a2 2 0 0 1-3.46 0" />
                   </svg>
                 </div>
-                <p className="text-sm font-medium text-text-secondary">No alerts yet</p>
+                <p className="text-sm font-medium text-text-secondary">No alerts today</p>
                 <p className="mt-1 text-xs text-text-muted">Run a scan to check for breakouts</p>
               </div>
             ) : (
-              alerts.slice(0, 20).map((alert, i) => (
+              todayAlerts.slice(0, 20).map((alert, i) => (
                 <button
                   key={alert.id}
                   onClick={() => onMarkRead(alert.id)}


### PR DESCRIPTION
## Summary
This PR improves reliability of NSE API interactions by implementing automatic retry logic with session reset, and enhances the dashboard by persisting scan results across page refreshes. It also refines alert filtering to show only today's alerts.

## Key Changes

### NSE Client Resilience
- Added `resetNse()` function to clear the singleton instance when API calls fail (stale cookies)
- Implemented `withRetry()` wrapper that automatically retries failed API calls after resetting the session
- Applied retry logic to all NSE API calls: `getHistoricalData()`, `getCurrentDayData()`, `getMarketStatus()`, `getNifty50Index()`, `searchStocks()`, and `getNifty50Snapshot()`

### Scan Results Persistence
- Added `ScanResult` type to store persistence layer
- Implemented `getScanResults()` and `saveScanResults()` functions in store.ts with Redis/filesystem fallback
- Modified scan API endpoint to persist results so they survive page refreshes
- Updated Dashboard to initialize with stored scan results

### Alert Filtering Improvements
- Added `getTodayIST()` helper to get today's date in IST timezone
- Modified `NotificationBell` to filter and display only today's alerts
- Updated `AlertPanel` to show only today's alerts instead of last 7 days
- Changed empty state messaging from "No alerts yet" to "No alerts today"

### Dashboard Initialization
- Dashboard now receives `initialResults` prop with persisted scan results
- Fixed `intraday` state initialization to use `isMarketHours()` instead of always starting as false
- Improved state management by loading scan results on page load

## Implementation Details
- Retry logic includes informative logging when first attempt fails
- Session reset happens before retry to clear stale cookies
- Scan results merging logic preserves existing results when doing close-watch-only scans
- All timezone-sensitive alert filtering uses IST to match market timezone

https://claude.ai/code/session_01SZZxUQTYX6GkfSshfeXtM1