### PR TITLE
feat: change volume alert to 3× average instead of max volume

### DIFF
--- a/src/app/api/nifty50/route.spec.ts
+++ b/src/app/api/nifty50/route.spec.ts
@@ -99,7 +99,7 @@ describe("Nifty50 route contracts", () => {
             symbol: "TCS",
             name: "TCS",
             dayHigh: 120,
-            totalTradedVolume: 1500,
+            totalTradedVolume: 3100, // >= 3×1000 avg threshold
             lastPrice: 118,
             pChange: 2,
           }),
@@ -107,7 +107,7 @@ describe("Nifty50 route contracts", () => {
             symbol: "ITC",
             name: "ITC",
             dayHigh: 210,
-            totalTradedVolume: 900,
+            totalTradedVolume: 900, // < 3×1000 avg threshold
             lastPrice: 205,
             pChange: 1,
           }),

--- a/src/app/api/nifty50/route.ts
+++ b/src/app/api/nifty50/route.ts
@@ -86,14 +86,15 @@ export async function GET() {
       }
 
       const highBreak = stock.dayHigh > baseline.maxHigh5d;
-      const volumeBreak = stock.totalTradedVolume > baseline.maxVolume5d;
+      const volumeThreshold = baseline.maxVolume5d * 3;
+      const volumeBreak = stock.totalTradedVolume >= volumeThreshold;
       const breakout = highBreak && volumeBreak;
 
       const highBreakPercent = baseline.maxHigh5d > 0
         ? Math.round(((stock.dayHigh - baseline.maxHigh5d) / baseline.maxHigh5d) * 10000) / 100
         : 0;
-      const volumeBreakPercent = baseline.maxVolume5d > 0
-        ? Math.round(((stock.totalTradedVolume - baseline.maxVolume5d) / baseline.maxVolume5d) * 10000) / 100
+      const volumeBreakPercent = volumeThreshold > 0
+        ? Math.round(((stock.totalTradedVolume - volumeThreshold) / volumeThreshold) * 10000) / 100
         : 0;
 
       discoveries.push({

--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -487,7 +487,7 @@ function notifyBreakout(
 
     cooldownMap.set(stock.symbol, now);
     new Notification(`Breakout: ${stock.symbol}`, {
-      body: `High \u20B9${stock.todayHigh.toLocaleString("en-IN")} (prev max \u20B9${stock.prevMaxHigh.toLocaleString("en-IN")})\nVol ${formatVol(stock.todayVolume)} (prev max ${formatVol(stock.prevMaxVolume)})`,
+      body: `High \u20B9${stock.todayHigh.toLocaleString("en-IN")} (prev max \u20B9${stock.prevMaxHigh.toLocaleString("en-IN")})\nVol ${formatVol(stock.todayVolume)} (3\u00D7 avg ${formatVol(stock.prevMaxVolume * 3)})`,
       icon: "/favicon.ico",
     });
   }

--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -125,7 +125,7 @@ export function NotificationBell({
                     </div>
                     <div className="text-text-secondary">
                       Vol: <span className="font-mono text-accent tabular-nums">{formatVolume(alert.todayVolume)}</span>
-                      <span className="text-text-muted"> vs {formatVolume(alert.prevMaxVolume)}</span>
+                      <span className="text-text-muted"> vs 3×avg {formatVolume(alert.prevMaxVolume * 3)}</span>
                     </div>
                   </div>
                   <div className={`mt-1.5 font-mono text-[10px] text-text-muted ${!alert.read ? "ml-[18px]" : ""}`}>

--- a/src/components/stock-card.tsx
+++ b/src/components/stock-card.tsx
@@ -24,7 +24,7 @@ export function StockCard({
   const isStale = result.dataSource === "stale";
   const isLive = result.dataSource === "live";
   const highBreaks = hasData && !isStale && result.todayHigh > result.prevMaxHigh;
-  const volBreaks = hasData && !isStale && result.todayVolume > result.prevMaxVolume;
+  const volBreaks = hasData && !isStale && result.todayVolume >= result.prevMaxVolume * 3;
 
   useEffect(() => {
     if (prevCloseWatch.current === closeWatch) return;

--- a/src/lib/baselines.ts
+++ b/src/lib/baselines.ts
@@ -51,7 +51,8 @@ export async function getBaseline(symbol: string): Promise<StockBaseline | null>
     const baseline: StockBaseline = {
       symbol,
       maxHigh5d: Math.max(...recentDays.map((d) => d.high)),
-      maxVolume5d: Math.max(...recentDays.map((d) => d.volume)),
+      maxVolume5d:
+        recentDays.reduce((sum, d) => sum + d.volume, 0) / recentDays.length,
       computedDate: today,
     };
 


### PR DESCRIPTION
Trigger alert when volume >= 3× the 5-day average daily volume instead of exceeding the 5-day max. Price condition unchanged (high > 5-day max high). Updates scanner, baselines, nifty50 route, UI labels, and tests.