### PR TITLE
Filter notifications to only true breakouts with volume

### DIFF
--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -498,7 +498,11 @@ function notifyDiscoveries(
 
   const now = Date.now();
 
-  for (const stock of stocks) {
+  // Only notify for true breakouts (high + volume); high-only breaks stay
+  // visible in the Nifty 50 discovery feed without triggering notifications.
+  const trueBreakouts = stocks.filter((s) => s.fullBreakout);
+
+  for (const stock of trueBreakouts) {
     const lastNotified = cooldownMap.get(stock.symbol) ?? 0;
     if (now - lastNotified < NOTIFY_COOLDOWN_MS) continue;
 


### PR DESCRIPTION
## Summary
Modified the notification logic to only trigger alerts for true breakouts (stocks with both high price movement AND volume increase), while allowing high-only breakouts to remain visible in the discovery feed without sending notifications.

## Key Changes
- Added filtering to `notifyDiscoveries()` to check the `fullBreakout` property before sending notifications
- Only stocks with `fullBreakout === true` now trigger notification alerts
- High-only breakouts continue to appear in the Nifty 50 discovery feed but no longer generate notifications

## Implementation Details
- Introduced `trueBreakouts` array that filters the input stocks based on the `fullBreakout` flag
- The notification cooldown and delivery logic remains unchanged, now operating only on the filtered subset
- This reduces notification noise while maintaining visibility of all breakout types in the UI

https://claude.ai/code/session_011PuE97PnAU8jxr6YZ9FmTi