### PR TITLE
Add 3D tilt effect to stock cards on pointer movement

### DIFF
--- a/src/components/stock-card.tsx
+++ b/src/components/stock-card.tsx
@@ -72,6 +72,7 @@ export function StockCard({
     const tiltY = gsap.quickTo(card, "rotationY", { duration: 0.5, ease: "power3" });
 
     const onPointerMove = (e: PointerEvent) => {
+      if (e.pointerType !== "mouse") return;
       const rect = card.getBoundingClientRect();
       const px = (e.clientX - rect.left) / rect.width;
       const py = (e.clientY - rect.top) / rect.height;
@@ -79,17 +80,27 @@ export function StockCard({
       tiltY(gsap.utils.interpolate(-8, 8, px));
     };
 
-    const onPointerLeave = () => {
+    const onPointerLeave = (e: PointerEvent) => {
+      if (e.pointerType !== "mouse") return;
+      tiltX(0);
+      tiltY(0);
+    };
+
+    const onTouchReset = () => {
       tiltX(0);
       tiltY(0);
     };
 
     card.addEventListener("pointermove", onPointerMove);
     card.addEventListener("pointerleave", onPointerLeave);
+    card.addEventListener("touchend", onTouchReset);
+    card.addEventListener("touchcancel", onTouchReset);
 
     return () => {
       card.removeEventListener("pointermove", onPointerMove);
       card.removeEventListener("pointerleave", onPointerLeave);
+      card.removeEventListener("touchend", onTouchReset);
+      card.removeEventListener("touchcancel", onTouchReset);
     };
   }, []);
 


### PR DESCRIPTION
## Summary
Enhanced the StockCard component with an interactive 3D tilt effect that responds to pointer movement, creating a more engaging and dynamic user experience.

## Key Changes
- **Added 3D perspective setup**: Configured `transformPerspective: 800` on the card element for proper 3D rendering
- **Implemented pointer-based tilt animation**: Created a new effect hook that tracks pointer position relative to the card and applies rotationX/rotationY transformations
  - Calculates normalized pointer coordinates (0-1 range) within the card bounds
  - Uses GSAP's `quickTo` for smooth, performant rotation animations with `power3` easing
  - Interpolates rotation values between -8° and 8° based on pointer position
- **Added pointer event handlers**: 
  - `pointermove`: Updates tilt rotation based on cursor position
  - `pointerleave`: Resets tilt to neutral (0°) when pointer leaves the card
- **Cleaned up hover styles**: Removed the `hover:-translate-y-0.5` transform class and updated transition from `duration-300` to `transition-shadow` to avoid conflicts with the 3D tilt effect

## Implementation Details
The 3D tilt effect is adapted from GSAP best practices and uses:
- `gsap.quickTo()` for efficient, continuous animation updates without creating new tweens
- `gsap.utils.interpolate()` to map pointer coordinates to rotation angles
- Proper event listener cleanup in the effect's return function to prevent memory leaks

https://claude.ai/code/session_01SBwGbXWivWkpf3nauom3Cj