### PR TITLE
feat: add basic auth with cookie-based session

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# ── Basic Auth ────────────────────────────────────────────────────────────────
+# Username and password for the login page
+AUTH_USERNAME=dad
+AUTH_PASSWORD=your-password-here
+
+# Random secret used to sign the session cookie.
+# Generate one with: openssl rand -hex 32
+AUTH_SECRET=replace-with-a-random-secret
+
+# ── Upstash Redis (optional) ───────────────────────────────────────────────────
+# Leave blank to use local filesystem persistence instead
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=

--- a/src/app/api/auth/route.ts
+++ b/src/app/api/auth/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createHmac } from "crypto";
+
+function sessionToken() {
+  return createHmac("sha256", process.env.AUTH_SECRET ?? "")
+    .update(process.env.AUTH_PASSWORD ?? "")
+    .digest("hex");
+}
+
+// POST /api/auth — validate credentials and set session cookie
+export async function POST(request: NextRequest) {
+  const { username, password } = await request.json();
+
+  if (
+    username !== process.env.AUTH_USERNAME ||
+    password !== process.env.AUTH_PASSWORD
+  ) {
+    return NextResponse.json({ error: "Invalid credentials" }, { status: 401 });
+  }
+
+  const response = NextResponse.json({ ok: true });
+  response.cookies.set("session", sessionToken(), {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    maxAge: 60 * 60 * 24 * 30, // 30 days
+    path: "/",
+  });
+  return response;
+}
+
+// DELETE /api/auth — clear session cookie (logout)
+export async function DELETE() {
+  const response = NextResponse.json({ ok: true });
+  response.cookies.delete("session");
+  return response;
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useState, FormEvent } from "react";
+import { useRouter } from "next/navigation";
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setError("");
+
+    try {
+      const res = await fetch("/api/auth", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username, password }),
+      });
+
+      if (res.ok) {
+        router.push("/");
+        router.refresh();
+      } else {
+        setError("Invalid username or password.");
+      }
+    } catch {
+      setError("Something went wrong. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <main className="min-h-screen flex items-center justify-center px-4">
+      <div className="w-full max-w-sm animate-scale-in">
+        {/* Header */}
+        <div className="text-center mb-8">
+          <h1
+            className="font-display text-2xl font-semibold text-gradient mb-1.5"
+          >
+            Nifty Breakout Scanner
+          </h1>
+          <p className="text-sm" style={{ color: "var(--text-secondary)" }}>
+            Sign in to continue
+          </p>
+        </div>
+
+        {/* Form card */}
+        <form
+          onSubmit={handleSubmit}
+          className="rounded-2xl p-6 space-y-4"
+          style={{
+            background: "var(--surface-raised)",
+            border: "1px solid var(--surface-border)",
+            boxShadow:
+              "0 4px 32px -4px rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.03)",
+          }}
+        >
+          {/* Username */}
+          <div className="space-y-1.5">
+            <label
+              htmlFor="username"
+              className="block text-xs font-medium uppercase tracking-wider"
+              style={{ color: "var(--text-secondary)" }}
+            >
+              Username
+            </label>
+            <input
+              id="username"
+              type="text"
+              autoComplete="username"
+              required
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              className="w-full rounded-xl px-3.5 py-2.5 text-sm outline-none transition-colors"
+              style={{
+                background: "var(--surface-overlay)",
+                border: "1px solid var(--surface-border)",
+                color: "var(--text-primary)",
+              }}
+              onFocus={(e) =>
+                (e.currentTarget.style.borderColor = "var(--accent)")
+              }
+              onBlur={(e) =>
+                (e.currentTarget.style.borderColor = "var(--surface-border)")
+              }
+            />
+          </div>
+
+          {/* Password */}
+          <div className="space-y-1.5">
+            <label
+              htmlFor="password"
+              className="block text-xs font-medium uppercase tracking-wider"
+              style={{ color: "var(--text-secondary)" }}
+            >
+              Password
+            </label>
+            <input
+              id="password"
+              type="password"
+              autoComplete="current-password"
+              required
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="w-full rounded-xl px-3.5 py-2.5 text-sm outline-none transition-colors"
+              style={{
+                background: "var(--surface-overlay)",
+                border: "1px solid var(--surface-border)",
+                color: "var(--text-primary)",
+              }}
+              onFocus={(e) =>
+                (e.currentTarget.style.borderColor = "var(--accent)")
+              }
+              onBlur={(e) =>
+                (e.currentTarget.style.borderColor = "var(--surface-border)")
+              }
+            />
+          </div>
+
+          {/* Error */}
+          {error && (
+            <p
+              className="text-sm rounded-lg px-3 py-2"
+              style={{
+                color: "var(--danger)",
+                background: "var(--danger-muted)",
+                border: "1px solid rgba(255, 71, 87, 0.2)",
+              }}
+            >
+              {error}
+            </p>
+          )}
+
+          {/* Submit */}
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full rounded-xl py-2.5 text-sm font-semibold transition-all duration-200"
+            style={{
+              background: loading ? "var(--accent-dim)" : "var(--accent)",
+              color: "#08090d",
+              cursor: loading ? "not-allowed" : "pointer",
+            }}
+          >
+            {loading ? "Signing in…" : "Sign in"}
+          </button>
+        </form>
+      </div>
+    </main>
+  );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createHmac } from "crypto";
+
+function expectedToken() {
+  return createHmac("sha256", process.env.AUTH_SECRET ?? "")
+    .update(process.env.AUTH_PASSWORD ?? "")
+    .digest("hex");
+}
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // Let the login page and auth API through unauthenticated
+  if (pathname.startsWith("/login") || pathname.startsWith("/api/auth")) {
+    return NextResponse.next();
+  }
+
+  const session = request.cookies.get("session")?.value;
+  if (session !== expectedToken()) {
+    return NextResponse.redirect(new URL("/login", request.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+};


### PR DESCRIPTION
- middleware.ts intercepts all routes, redirects to /login if the session cookie is absent or invalid
- /api/auth POST validates username+password from env vars and sets a 30-day HttpOnly session cookie; DELETE clears it (logout)
- /login page matches the app design (dark surface, accent green)
- .env.example documents the three new AUTH_* variables

Session token = HMAC-SHA256(AUTH_SECRET, AUTH_PASSWORD) — static and invalidated automatically when either value changes in env.

https://claude.ai/code/session_01SBwGbXWivWkpf3nauom3Cj