### PR TITLE
fix: don't grant lockdown bypass on login

### DIFF
--- a/src/app/api/auth/route.ts
+++ b/src/app/api/auth/route.ts
@@ -40,7 +40,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Invalid credentials" }, { status: 401 });
   }
 
-  // Read current security state for epoch + lockdown
+  // Read current security state for epoch
   const state = await getSecurityState();
 
   const response = NextResponse.json({ ok: true });
@@ -52,16 +52,10 @@ export async function POST(request: NextRequest) {
     path: "/",
   });
 
-  // If lockdown is active, grant bypass to the authenticated owner
-  if (state.lockdown?.active) {
-    response.cookies.set("lockdown-bypass", state.lockdown.bypassToken, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === "production",
-      sameSite: "lax",
-      maxAge: 60 * 60 * 24, // 24 hours
-      path: "/",
-    });
-  }
+  // NOTE: We intentionally do NOT grant the lockdown-bypass cookie here.
+  // The bypass is only issued when lockdown is activated from the admin
+  // panel.  If we handed it out on every successful login, anyone who
+  // knows the credentials could bypass lockdown — defeating its purpose.
 
   return response;
 }


### PR DESCRIPTION
Previously POST /api/auth would hand out the lockdown-bypass cookie to anyone who logged in with valid credentials during a lockdown. Since /api/auth is a public path (not blocked by lockdown), this meant anyone with the password could bypass lockdown entirely — defeating its purpose.

The bypass cookie is now only issued when lockdown is activated from the admin panel.  If the admin loses their bypass cookie they must wait for auto-expire or use another authenticated session to deactivate lockdown.

https://claude.ai/code/session_01L2293s755Z8RmZGiFZgfcT