### PR TITLE
feat: separate admin credentials for lockdown bypass

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,12 @@
 AUTH_USERNAME=dad
 AUTH_PASSWORD=your-password-here
 
+# ── Admin Auth (lockdown bypass) ─────────────────────────────────────────────
+# Separate credentials that can bypass lockdown mode.
+# Regular AUTH_USERNAME/AUTH_PASSWORD cannot bypass lockdown.
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=your-admin-password-here
+
 # Random secret used to sign the session cookie.
 # Generate one with: openssl rand -hex 32
 AUTH_SECRET=replace-with-a-random-secret


### PR DESCRIPTION
Add ADMIN_USERNAME / ADMIN_PASSWORD env vars. During lockdown:
- Regular credentials (AUTH_*) authenticate but stay blocked
- Admin credentials (ADMIN_*) authenticate AND receive the lockdown-bypass cookie, allowing full access

This closes the hole where anyone with the shared password could log in and walk through lockdown via /api/auth.

https://claude.ai/code/session_01L2293s755Z8RmZGiFZgfcT