### PR TITLE
feat: redesign AlertsSection into bento card with GSAP counter popovers

### DIFF
--- a/src/app/api/state/route.ts
+++ b/src/app/api/state/route.ts
@@ -4,6 +4,7 @@ import { getScanMeta } from "@/lib/activity";
 import { getMarketStatus, getHistoricalCacheStats, getNifty50Index, getApiStats } from "@/lib/nse-client";
 import { getBaselineStats } from "@/lib/baselines";
 import { flushStats, getPersistedStats } from "@/lib/api-stats";
+import { getAlertRequests } from "@/lib/alert-requests";
 
 export const dynamic = "force-dynamic";
 
@@ -11,7 +12,7 @@ export async function GET() {
   // Lazy flush: write pending API stat deltas to Redis on each poll
   await flushStats().catch(() => {});
 
-  const [watchlist, alerts, scanMeta, marketOpen, cacheStats, nifty, nifty50Stats, persistedApiStats] =
+  const [watchlist, alerts, scanMeta, marketOpen, cacheStats, nifty, nifty50Stats, persistedApiStats, alertRequests] =
     await Promise.all([
       getWatchlist(),
       getAlerts(),
@@ -21,6 +22,7 @@ export async function GET() {
       getNifty50Index().catch(() => null),
       getNifty50PersistentStats(),
       getPersistedStats(),
+      getAlertRequests().catch(() => [] as import("@/lib/types").AlertRequest[]),
     ]);
 
   const closeWatchStocks = watchlist.filter((s) => s.closeWatch);
@@ -51,6 +53,15 @@ export async function GET() {
     },
   };
 
+  // Alert request status breakdown
+  const alertRequestsByStatus: Record<string, number> = {};
+  for (const r of alertRequests) {
+    alertRequestsByStatus[r.status] = (alertRequestsByStatus[r.status] ?? 0) + 1;
+  }
+  const inProgressCount = alertRequests.filter(
+    (r) => r.status !== "implemented" && r.status !== "rejected"
+  ).length;
+
   return NextResponse.json({
     market: { open: marketOpen },
     watchlist: {
@@ -64,6 +75,19 @@ export async function GET() {
       nifty50Alerts: nifty50Alerts.length,
       scanAlerts: scanAlerts.length,
       recentSymbols: alerts.slice(0, 5).map((a) => a.symbol),
+    },
+    alertRequests: {
+      total: alertRequests.length,
+      inProgress: inProgressCount,
+      byStatus: alertRequestsByStatus,
+      recent: alertRequests.slice(0, 5).map((r) => ({
+        id: r.id,
+        text: r.text.replace(/^Create Alert:\s*/i, ""),
+        status: r.status,
+        createdAt: r.createdAt,
+        githubIssueNumber: r.githubIssueNumber,
+        githubPrNumber: r.githubPrNumber,
+      })),
     },
     scan: scanMeta,
     cache: cacheStats,

--- a/src/app/dev/page.tsx
+++ b/src/app/dev/page.tsx
@@ -59,10 +59,25 @@ interface CacheLayersData {
   };
 }
 
+interface AlertRequestSummary {
+  total: number;
+  inProgress: number;
+  byStatus: Record<string, number>;
+  recent: {
+    id: string;
+    text: string;
+    status: string;
+    createdAt: string;
+    githubIssueNumber?: number;
+    githubPrNumber?: number;
+  }[];
+}
+
 interface SystemState {
   market: { open: boolean };
   watchlist: { total: number; closeWatch: number; closeWatchSymbols: string[] };
   alerts: { total: number; unread: number; nifty50Alerts?: number; scanAlerts?: number; recentSymbols?: string[] };
+  alertRequests?: AlertRequestSummary;
   scan: ScanMeta | null;
   cache: { size: number; symbols: string[]; date: string };
   cacheLayers?: CacheLayersData;
@@ -1031,6 +1046,114 @@ export default function DevDashboard() {
                                 <span className="text-text-secondary font-mono truncate">{r.method}{r.symbol ? ` (${r.symbol})` : ''}</span>
                               </div>
                             ))}
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  </CollapsibleSection>
+                );
+              })()}
+
+              {state?.alertRequests && (() => {
+                const ar = state.alertRequests;
+                const STATUS_COLORS: Record<string, { dot: string; text: string; bg: string }> = {
+                  pending:       { dot: 'bg-amber-400',   text: 'text-amber-400',   bg: 'bg-amber-500/10' },
+                  issue_created: { dot: 'bg-blue-400',    text: 'text-blue-400',    bg: 'bg-blue-500/10' },
+                  pr_created:    { dot: 'bg-violet-400',  text: 'text-violet-400',  bg: 'bg-violet-500/10' },
+                  implemented:   { dot: 'bg-emerald-400', text: 'text-emerald-400', bg: 'bg-emerald-500/10' },
+                  rejected:      { dot: 'bg-red-400',     text: 'text-red-400',     bg: 'bg-red-500/10' },
+                };
+                const STATUS_LABELS: Record<string, string> = {
+                  pending: 'Pending',
+                  issue_created: 'Issue',
+                  pr_created: 'PR',
+                  implemented: 'Done',
+                  rejected: 'Rejected',
+                };
+                return (
+                  <CollapsibleSection
+                    title="Alert Requests"
+                    icon={<svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>}
+                    badge={ar.inProgress > 0 ? `${ar.inProgress} active` : `${ar.total} total`}
+                    badgeColor={ar.inProgress > 0 ? 'bg-amber-500/10 text-amber-400' : 'bg-surface-overlay text-text-muted'}
+                    defaultOpen={ar.inProgress > 0}
+                  >
+                    <div className="space-y-3 pt-2.5">
+                      {/* Summary stats */}
+                      <div className="grid grid-cols-2 gap-2">
+                        <div>
+                          <p className="text-[9px] text-text-muted font-semibold mb-1">Total</p>
+                          <p className="text-sm font-bold tabular-nums">{ar.total}</p>
+                        </div>
+                        <div>
+                          <p className="text-[9px] text-text-muted font-semibold mb-1">In Progress</p>
+                          <p className={`text-sm font-bold tabular-nums ${ar.inProgress > 0 ? 'text-amber-400' : 'text-text-muted'}`}>
+                            {ar.inProgress}
+                          </p>
+                        </div>
+                      </div>
+
+                      {/* Status breakdown */}
+                      {Object.keys(ar.byStatus).length > 0 && (
+                        <div>
+                          <p className="text-[9px] text-text-muted/50 font-semibold mb-1.5">Status Breakdown</p>
+                          <div className="flex flex-wrap gap-1.5">
+                            {Object.entries(ar.byStatus).map(([status, count]) => {
+                              const colors = STATUS_COLORS[status] ?? { dot: 'bg-slate-400', text: 'text-slate-400', bg: 'bg-slate-500/10' };
+                              const label = STATUS_LABELS[status] ?? status;
+                              return (
+                                <span key={status} className={`inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-[9px] font-semibold ${colors.bg} ${colors.text}`}>
+                                  <span className={`h-1 w-1 rounded-full ${colors.dot}`} />
+                                  {label}: {count}
+                                </span>
+                              );
+                            })}
+                          </div>
+                        </div>
+                      )}
+
+                      {/* Progress bar */}
+                      {ar.total > 0 && (
+                        <div>
+                          <div className="flex h-1.5 w-full overflow-hidden rounded-full bg-surface-overlay">
+                            {Object.entries(ar.byStatus).map(([status, count]) => {
+                              const colors = STATUS_COLORS[status];
+                              const pct = (count / ar.total) * 100;
+                              return pct > 0 ? (
+                                <div key={status} className={`${colors?.dot ?? 'bg-slate-400'} transition-all duration-500`} style={{ width: `${pct}%` }} />
+                              ) : null;
+                            })}
+                          </div>
+                        </div>
+                      )}
+
+                      {/* Recent requests */}
+                      {ar.recent.length > 0 && (
+                        <div>
+                          <p className="text-[9px] text-text-muted/50 font-semibold mb-1.5">Recent Requests</p>
+                          <div className="space-y-1.5">
+                            {ar.recent.map((req) => {
+                              const colors = STATUS_COLORS[req.status] ?? { dot: 'bg-slate-400', text: 'text-slate-400', bg: 'bg-slate-500/10' };
+                              const label = STATUS_LABELS[req.status] ?? req.status;
+                              return (
+                                <div key={req.id} className="flex items-start gap-2 rounded-lg border border-surface-border/30 bg-surface/40 px-2.5 py-2">
+                                  <span className={`mt-1 h-1.5 w-1.5 flex-shrink-0 rounded-full ${colors.dot}`} />
+                                  <div className="min-w-0 flex-1">
+                                    <p className="text-[10px] text-text-primary font-medium leading-relaxed truncate">{req.text}</p>
+                                    <div className="mt-0.5 flex items-center gap-2">
+                                      <span className={`text-[8px] font-bold uppercase tracking-wider ${colors.text}`}>{label}</span>
+                                      <span className="text-[8px] text-text-muted/40 font-mono tabular-nums">{timeAgo(req.createdAt)}</span>
+                                      {req.githubIssueNumber && (
+                                        <span className="text-[8px] text-blue-400/60">#{req.githubIssueNumber}</span>
+                                      )}
+                                      {req.githubPrNumber && (
+                                        <span className="text-[8px] text-violet-400/60">PR #{req.githubPrNumber}</span>
+                                      )}
+                                    </div>
+                                  </div>
+                                </div>
+                              );
+                            })}
                           </div>
                         </div>
                       )}

--- a/src/components/alert-builder.tsx
+++ b/src/components/alert-builder.tsx
@@ -5,7 +5,7 @@ import { Sparkles, Send, Loader2, CheckCircle2, AlertCircle } from "lucide-react
 
 type FeedbackState = { type: "success" | "error"; message: string } | null;
 
-export function AlertBuilder() {
+export function AlertBuilder({ onSubmitted }: { onSubmitted?: () => void } = {}) {
   const [text, setText] = useState("");
   const [loading, setLoading] = useState(false);
   const [feedback, setFeedback] = useState<FeedbackState>(null);
@@ -43,6 +43,7 @@ export function AlertBuilder() {
 
       setText("");
       showFeedback("success", "Alert submitted — a GitHub Issue has been created for review.");
+      onSubmitted?.();
     } catch (err) {
       const message = err instanceof Error ? err.message : "Something went wrong";
       showFeedback("error", message);

--- a/src/components/alerts-section.tsx
+++ b/src/components/alerts-section.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import gsap from "gsap";
+import type { Alert, AlertRequest } from "@/lib/types";
+import { AlertBuilder } from "./alert-builder";
+
+/* ── Static alert types ────────────────────────────────────────────── */
+
+const CONFIGURED_ALERT_TYPES = [
+  { id: "true-breakout", name: "True Breakout", status: "active" as const },
+  { id: "low-breakout", name: "Low Breakout", status: "planned" as const },
+];
+
+/* ── Helpers ─────────────────────────────────────────────────────────── */
+
+function stripPrefix(text: string): string {
+  return text.replace(/^Create Alert:\s*/i, "");
+}
+
+/* ── Main Component ─────────────────────────────────────────────────── */
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function AlertsSection({ alerts }: { alerts: Alert[] }) {
+  const [alertRequests, setAlertRequests] = useState<AlertRequest[]>([]);
+  const [configuredOpen, setConfiguredOpen] = useState(false);
+  const [inProgressOpen, setInProgressOpen] = useState(false);
+  const fetchedRef = useRef(false);
+
+  const configuredWrapperRef = useRef<HTMLDivElement>(null);
+  const configuredBubbleRef = useRef<HTMLDivElement>(null);
+  const inProgressWrapperRef = useRef<HTMLDivElement>(null);
+  const inProgressBubbleRef = useRef<HTMLDivElement>(null);
+
+  const inProgressRequests = alertRequests.filter(
+    (r) => r.status !== "implemented" && r.status !== "rejected"
+  );
+
+  const fetchRequests = useCallback(async () => {
+    try {
+      const res = await fetch("/api/alert-requests");
+      if (res.ok) {
+        const data = await res.json();
+        if (Array.isArray(data)) setAlertRequests(data);
+      }
+    } catch { /* silent */ }
+  }, []);
+
+  useEffect(() => {
+    if (!fetchedRef.current) {
+      fetchedRef.current = true;
+      fetchRequests();
+    }
+  }, [fetchRequests]);
+
+  const handleRequestSubmitted = useCallback(() => {
+    setTimeout(fetchRequests, 500);
+  }, [fetchRequests]);
+
+  /* ── GSAP bubble animations ───────────────────────────────────────── */
+
+  const animateOpen = useCallback((el: HTMLDivElement | null) => {
+    if (!el) return;
+    gsap.killTweensOf(el);
+    gsap.set(el, { visibility: "visible" });
+    gsap.fromTo(
+      el,
+      { opacity: 0, y: -6, scale: 0.95 },
+      { opacity: 1, y: 0, scale: 1, duration: 0.25, ease: "power2.out" }
+    );
+  }, []);
+
+  const animateClose = useCallback((el: HTMLDivElement | null) => {
+    if (!el) return;
+    gsap.killTweensOf(el);
+    gsap.to(el, {
+      opacity: 0,
+      y: -4,
+      scale: 0.97,
+      duration: 0.18,
+      ease: "power2.in",
+      onComplete: () => { gsap.set(el, { visibility: "hidden" }); },
+    });
+  }, []);
+
+  useEffect(() => {
+    if (configuredOpen) {
+      animateOpen(configuredBubbleRef.current);
+    } else {
+      animateClose(configuredBubbleRef.current);
+    }
+  }, [configuredOpen, animateOpen, animateClose]);
+
+  useEffect(() => {
+    if (inProgressOpen) {
+      animateOpen(inProgressBubbleRef.current);
+    } else {
+      animateClose(inProgressBubbleRef.current);
+    }
+  }, [inProgressOpen, animateOpen, animateClose]);
+
+  /* ── Click-outside dismissal ──────────────────────────────────────── */
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (
+        configuredWrapperRef.current &&
+        !configuredWrapperRef.current.contains(e.target as Node)
+      ) {
+        setConfiguredOpen(false);
+      }
+      if (
+        inProgressWrapperRef.current &&
+        !inProgressWrapperRef.current.contains(e.target as Node)
+      ) {
+        setInProgressOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  /* ── Render ───────────────────────────────────────────────────────── */
+
+  return (
+    <div className="animate-fade-in">
+      <div
+        className="rounded-2xl ring-1 ring-surface-border/50 card-elevated overflow-visible"
+        style={{
+          background: "linear-gradient(180deg, rgba(14, 16, 23, 1) 0%, rgba(11, 13, 18, 1) 100%)",
+        }}
+      >
+        {/* Subtle accent top edge */}
+        <div
+          className="h-[1px] rounded-t-2xl"
+          style={{
+            background: "linear-gradient(90deg, transparent 10%, rgba(0, 230, 138, 0.15) 50%, transparent 90%)",
+          }}
+        />
+
+        {/* Header row */}
+        <div className="flex items-center justify-between px-5 pt-3.5 pb-2.5">
+          <div className="flex items-center gap-2.5">
+            <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-accent/10 ring-1 ring-accent/20">
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="text-accent">
+                <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+                <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+              </svg>
+            </div>
+            <h2 className="font-display text-sm font-bold tracking-tight">Alerts</h2>
+          </div>
+
+          {/* Counter badges */}
+          <div className="flex items-center gap-2">
+            {/* Configured types counter */}
+            <div className="relative" ref={configuredWrapperRef}>
+              <button
+                onClick={() => {
+                  const next = !configuredOpen;
+                  setConfiguredOpen(next);
+                  if (next && inProgressOpen) setInProgressOpen(false);
+                }}
+                className={`flex items-center gap-1.5 rounded-lg px-2.5 py-1 font-mono text-[10px] font-bold tabular-nums cursor-pointer transition-all duration-200 ring-1 ${
+                  configuredOpen
+                    ? "bg-accent/15 ring-accent/30 text-accent"
+                    : "bg-accent/8 ring-accent/15 text-accent hover:ring-accent/25 hover:bg-accent/12"
+                }`}
+              >
+                <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" className="flex-shrink-0">
+                  <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" />
+                </svg>
+                {CONFIGURED_ALERT_TYPES.length}
+                <span className="text-[8px] font-semibold uppercase tracking-wider opacity-60">cfg</span>
+              </button>
+
+              {/* Configured types popover */}
+              <div
+                ref={configuredBubbleRef}
+                className="absolute right-0 top-full mt-2 z-40 w-[210px] overflow-hidden rounded-xl bg-surface-overlay ring-1 ring-surface-border-bright/60 shadow-2xl shadow-black/60"
+                style={{ opacity: 0, visibility: "hidden" }}
+              >
+                <div className="px-3 py-2.5 space-y-1">
+                  <p className="text-[9px] font-bold uppercase tracking-wider text-text-muted mb-1.5">Alert Types</p>
+                  {CONFIGURED_ALERT_TYPES.map((type) => (
+                    <div key={type.id} className="flex items-center gap-2 py-1">
+                      <span
+                        className={`h-1.5 w-1.5 rounded-full flex-shrink-0 ${
+                          type.status === "active"
+                            ? "bg-accent shadow-[0_0_4px_rgba(0,230,138,0.4)]"
+                            : "bg-text-muted/40"
+                        }`}
+                      />
+                      <span className="text-[11px] font-medium text-text-primary">{type.name}</span>
+                      <span
+                        className={`ml-auto text-[8px] font-bold uppercase tracking-wider ${
+                          type.status === "active" ? "text-accent/60" : "text-text-muted/50"
+                        }`}
+                      >
+                        {type.status}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+
+            {/* In-progress counter (only visible when > 0) */}
+            {inProgressRequests.length > 0 && (
+              <div className="relative" ref={inProgressWrapperRef}>
+                <button
+                  onClick={() => {
+                    const next = !inProgressOpen;
+                    setInProgressOpen(next);
+                    if (next && configuredOpen) setConfiguredOpen(false);
+                  }}
+                  className={`flex items-center gap-1.5 rounded-lg px-2.5 py-1 font-mono text-[10px] font-bold tabular-nums cursor-pointer transition-all duration-200 ring-1 ${
+                    inProgressOpen
+                      ? "bg-amber-500/15 ring-amber-500/30 text-amber-400"
+                      : "bg-amber-500/8 ring-amber-500/15 text-amber-400 hover:ring-amber-500/25 hover:bg-amber-500/12"
+                  }`}
+                >
+                  <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" className="flex-shrink-0">
+                    <circle cx="12" cy="12" r="10" />
+                    <path d="M12 6v6l4 2" />
+                  </svg>
+                  {inProgressRequests.length}
+                  <span className="text-[8px] font-semibold uppercase tracking-wider opacity-60">wip</span>
+                </button>
+
+                {/* In-progress popover */}
+                <div
+                  ref={inProgressBubbleRef}
+                  className="absolute right-0 top-full mt-2 z-40 w-[250px] overflow-hidden rounded-xl bg-surface-overlay ring-1 ring-surface-border-bright/60 shadow-2xl shadow-black/60"
+                  style={{ opacity: 0, visibility: "hidden" }}
+                >
+                  <div className="px-3 py-2.5 space-y-1">
+                    <p className="text-[9px] font-bold uppercase tracking-wider text-text-muted mb-1.5">Building</p>
+                    {inProgressRequests.map((req) => (
+                      <div key={req.id} className="flex items-start gap-2 py-1">
+                        <span className="mt-1 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-amber-400/60" />
+                        <p className="text-[11px] font-medium text-text-primary leading-snug line-clamp-2">
+                          {stripPrefix(req.text)}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Separator */}
+        <div className="mx-5 border-t border-surface-border/30" />
+
+        {/* Alert Builder */}
+        <div className="px-5 pt-3 pb-4">
+          <AlertBuilder onSubmitted={handleRequestSubmitted} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -4,12 +4,11 @@ import { useState, useCallback, useEffect, useRef } from "react";
 import { Header } from "./header";
 import { ScanButton } from "./scan-button";
 import { StockCard } from "./stock-card";
-import { AlertPanel } from "./alert-panel";
 import { TickerPanel } from "./ticker-panel";
 import { Nifty50Rail } from "./nifty50-rail";
 import { DiscoveryFeed } from "./discovery-feed";
 import { AddStockModal } from "./add-stock-modal";
-import { AlertBuilder } from "./alert-builder";
+import { AlertsSection } from "./alerts-section";
 import { isMarketHours } from "@/lib/market-hours";
 import type { WatchlistStock, ScanResult, Alert, DiscoveryStock } from "@/lib/types";
 
@@ -276,10 +275,8 @@ export function Dashboard({
       )}
 
       <main className="mx-auto max-w-[1440px] px-5 py-8 space-y-6">
-        <AlertBuilder />
-
-        {/* Alerts — horizontal scrollable strip */}
-        <AlertPanel alerts={alerts} />
+        {/* Alerts — Configured + In Progress */}
+        <AlertsSection alerts={alerts} />
 
         <TickerPanel
           hasCloseWatchStocks={closeWatchCount > 0}


### PR DESCRIPTION
- New alerts-section.tsx: compact bento card layout replacing full card sections
  - Header row with bell icon + "Alerts" title + inline cfg/wip counter badges
  - Subtle accent gradient glow on top edge of the card
  - Thin separator between header and AlertBuilder input
  - GSAP-animated popovers (scale+opacity+y) on badge click
  - Click-outside dismissal; popovers mutually exclusive
- alert-builder.tsx: adds onSubmitted callback prop
- dashboard.tsx: integrates AlertsSection with alerts prop
- api/state/route.ts: exposes alertRequests data in /api/state response
- dev/page.tsx: adds Alert Requests collapsible section in dev dashboard