### PR TITLE
feat: add Low Breakout push alerts (high-only price break)

### DIFF
--- a/src/app/api/nifty50/route.ts
+++ b/src/app/api/nifty50/route.ts
@@ -155,6 +155,52 @@ export async function GET() {
           );
         }
       }
+
+      // Fire alert for high-only breaks (price new high, volume below threshold)
+      if (highBreak && !volumeBreak) {
+        const alertId = `${stock.symbol}-nifty50-low-breakout-${today}`;
+        const alert: Alert = {
+          id: alertId,
+          symbol: stock.symbol,
+          name: stock.name,
+          alertType: "low-breakout",
+          todayHigh: stock.dayHigh,
+          todayVolume: stock.totalTradedVolume,
+          prevMaxHigh: baseline.maxHigh5d,
+          prevMaxVolume: baseline.maxVolume5d,
+          highBreakPercent,
+          volumeBreakPercent,
+          todayClose: stock.lastPrice,
+          todayChange: stock.pChange,
+          prev10DayLow: 0,
+          lowBreakPercent: 0,
+          triggeredAt: new Date().toISOString(),
+          read: false,
+        };
+        const added = await addAlert(alert);
+        newAlerts.push(alert);
+
+        if (added) {
+          await addActivity(
+            "system",
+            "alert-fired",
+            `Nifty 50 alert: ${stock.symbol} high-only break — High +${highBreakPercent}%`,
+            {
+              actor: "system",
+              detail: {
+                source: "nifty50",
+                symbol: stock.symbol,
+                highBreakPercent,
+                volumeBreakPercent,
+                todayHigh: stock.dayHigh,
+                todayVolume: stock.totalTradedVolume,
+                prevMaxHigh: baseline.maxHigh5d,
+                prevMaxVolume: baseline.maxVolume5d,
+              },
+            },
+          );
+        }
+      }
     }
 
     // Activity tracking for discoveries

--- a/src/app/api/state/route.ts
+++ b/src/app/api/state/route.ts
@@ -29,7 +29,7 @@ export async function GET() {
   const unreadAlerts = alerts.filter((a) => !a.read).length;
 
   // Break down alerts by type
-  const nifty50Alerts = alerts.filter((a) => a.alertType === "breakout");
+  const nifty50Alerts = alerts.filter((a) => a.alertType === "breakout" || a.alertType === "low-breakout");
   const scanAlerts = alerts.filter((a) => !a.alertType || a.alertType === "scan");
 
   // Cache layer breakdown from apiStats

--- a/src/components/alerts-section.tsx
+++ b/src/components/alerts-section.tsx
@@ -9,7 +9,7 @@ import { AlertBuilder } from "./alert-builder";
 
 const CONFIGURED_ALERT_TYPES = [
   { id: "true-breakout", name: "True Breakout", status: "active" as const },
-  { id: "low-breakout", name: "Low Breakout", status: "planned" as const },
+  { id: "low-breakout", name: "Low Breakout", status: "active" as const },
 ];
 
 /* ── Helpers ─────────────────────────────────────────────────────────── */

--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -114,8 +114,12 @@ export function NotificationBell({
                         <span className="ml-2 text-xs text-text-muted">{alert.name}</span>
                       </div>
                     </div>
-                    <span className="flex-shrink-0 rounded-md bg-accent/10 ring-1 ring-accent/15 px-1.5 py-0.5 font-mono text-[9px] font-bold tracking-wider text-accent">
-                      BREAKOUT
+                    <span className={`flex-shrink-0 rounded-md px-1.5 py-0.5 font-mono text-[9px] font-bold tracking-wider ring-1 ${
+                      alert.alertType === "low-breakout"
+                        ? "bg-amber-500/10 ring-amber-500/15 text-amber-400"
+                        : "bg-accent/10 ring-accent/15 text-accent"
+                    }`}>
+                      {alert.alertType === "low-breakout" ? "LOW BREAK" : "BREAKOUT"}
                     </span>
                   </div>
                   <div className={`mt-2 grid grid-cols-2 gap-x-4 gap-y-1 text-xs ${!alert.read ? "ml-[18px]" : ""}`}>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -35,7 +35,7 @@ export interface Alert {
   id: string;
   symbol: string;
   name: string;
-  alertType?: "breakout" | "scan";
+  alertType?: "breakout" | "low-breakout" | "scan";
   todayHigh: number;
   todayVolume: number;
   prevMaxHigh: number;


### PR DESCRIPTION
- types.ts: add "low-breakout" to alertType union
- nifty50/route.ts: fire addAlert() when highBreak && !volumeBreak, deduped per symbol per day with alertType "low-breakout"
- state/route.ts: include "low-breakout" in nifty50Alerts filter
- notification-bell.tsx: show amber "LOW BREAK" badge for low-breakout alerts
- alerts-section.tsx: mark Low Breakout status as "active"