### PR TITLE
feat: migrate agent workflow to OAuth, add alert status controls and …

### DIFF
--- a/.github/workflows/agent-create-alert.yml
+++ b/.github/workflows/agent-create-alert.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             You are implementing a new alert type for the NSE stock scanner.
 

--- a/src/app/api/alert-requests/[id]/route.ts
+++ b/src/app/api/alert-requests/[id]/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { updateAlertRequestStatus } from "@/lib/alert-requests";
+import { addActivity } from "@/lib/activity";
+import type { AlertRequestStatus } from "@/lib/types";
+
+export const dynamic = "force-dynamic";
+
+const FINAL_STATUSES = new Set<AlertRequestStatus>(["implemented", "rejected"]);
+
+const PatchSchema = z.object({
+  status: z.enum(["pending", "issue_created", "pr_created", "implemented", "rejected"]),
+});
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const body = await request.json();
+    const parsed = PatchSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0]?.message ?? "Invalid input" },
+        { status: 400 }
+      );
+    }
+
+    const { status } = parsed.data;
+    const { id } = params;
+
+    await updateAlertRequestStatus(id, status as AlertRequestStatus);
+
+    await addActivity("system", `alert-request-${status}`, `Alert request manually marked ${status}`, {
+      detail: { requestId: id },
+    });
+
+    return NextResponse.json({ ok: true });
+  } catch {
+    return NextResponse.json({ error: "Failed to update alert request" }, { status: 500 });
+  }
+}

--- a/src/app/dev/page.tsx
+++ b/src/app/dev/page.tsx
@@ -514,6 +514,7 @@ export default function DevDashboard() {
   const [autoRefresh, setAutoRefresh] = useState(true);
   const [timelineFilter, setTimelineFilter] = useState<TimelineFilter>('all');
   const [expandedEvent, setExpandedEvent] = useState<string | null>(null);
+  const [updatingAlertId, setUpdatingAlertId] = useState<string | null>(null);
 
   const timelineRef = useRef<HTMLDivElement>(null);
   const sidebarRef = useRef<HTMLDivElement>(null);
@@ -549,6 +550,19 @@ export default function DevDashboard() {
       setEvents(activityData.events || []);
     } catch { }
   }, []);
+
+  const patchAlertStatus = useCallback(async (id: string, status: string) => {
+    setUpdatingAlertId(id);
+    try {
+      await fetch(`/api/alert-requests/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status }),
+      });
+      await fetchAll();
+    } catch { }
+    finally { setUpdatingAlertId(null); }
+  }, [fetchAll]);
 
   const fetchLogs = useCallback(async () => {
     try {
@@ -1140,7 +1154,7 @@ export default function DevDashboard() {
                                   <span className={`mt-1 h-1.5 w-1.5 flex-shrink-0 rounded-full ${colors.dot}`} />
                                   <div className="min-w-0 flex-1">
                                     <p className="text-[10px] text-text-primary font-medium leading-relaxed truncate">{req.text}</p>
-                                    <div className="mt-0.5 flex items-center gap-2">
+                                    <div className="mt-0.5 flex items-center gap-2 flex-wrap">
                                       <span className={`text-[8px] font-bold uppercase tracking-wider ${colors.text}`}>{label}</span>
                                       <span className="text-[8px] text-text-muted/40 font-mono tabular-nums">{timeAgo(req.createdAt)}</span>
                                       {req.githubIssueNumber && (
@@ -1150,6 +1164,24 @@ export default function DevDashboard() {
                                         <span className="text-[8px] text-violet-400/60">PR #{req.githubPrNumber}</span>
                                       )}
                                     </div>
+                                    {req.status !== 'implemented' && req.status !== 'rejected' && (
+                                      <div className="mt-1.5 flex items-center gap-1.5">
+                                        <button
+                                          onClick={() => patchAlertStatus(req.id, 'implemented')}
+                                          disabled={updatingAlertId === req.id}
+                                          className="rounded px-1.5 py-0.5 text-[8px] font-semibold text-emerald-400 border border-emerald-500/20 bg-emerald-500/[0.07] hover:bg-emerald-500/15 transition-colors disabled:opacity-40"
+                                        >
+                                          {updatingAlertId === req.id ? '…' : '✓ Implemented'}
+                                        </button>
+                                        <button
+                                          onClick={() => patchAlertStatus(req.id, 'rejected')}
+                                          disabled={updatingAlertId === req.id}
+                                          className="rounded px-1.5 py-0.5 text-[8px] font-semibold text-red-400 border border-red-500/20 bg-red-500/[0.07] hover:bg-red-500/15 transition-colors disabled:opacity-40"
+                                        >
+                                          Reject
+                                        </button>
+                                      </div>
+                                    )}
                                   </div>
                                 </div>
                               );

--- a/src/components/alert-builder.tsx
+++ b/src/components/alert-builder.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useRef } from "react";
-import { Sparkles, Send, Loader2, CheckCircle2, AlertCircle } from "lucide-react";
+import { useState, useRef, useEffect } from "react";
+import { Sparkles, Send, Loader2, CheckCircle2, AlertCircle, Info } from "lucide-react";
 
 type FeedbackState = { type: "success" | "error"; message: string } | null;
 
@@ -9,8 +9,21 @@ export function AlertBuilder({ onSubmitted }: { onSubmitted?: () => void } = {})
   const [text, setText] = useState("");
   const [loading, setLoading] = useState(false);
   const [feedback, setFeedback] = useState<FeedbackState>(null);
+  const [showHint, setShowHint] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout>>();
+  const hintRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!showHint) return;
+    const handler = (e: MouseEvent) => {
+      if (hintRef.current && !hintRef.current.contains(e.target as Node)) {
+        setShowHint(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [showHint]);
 
   const showFeedback = (type: "success" | "error", message: string) => {
     if (timerRef.current) clearTimeout(timerRef.current);
@@ -61,7 +74,7 @@ export function AlertBuilder({ onSubmitted }: { onSubmitted?: () => void } = {})
   };
 
   return (
-    <div className="animate-fade-in">
+    <div className="animate-fade-in relative" ref={hintRef}>
       <div
         className="rounded-[1.8rem] p-[1.5px] shadow-lg shadow-black/30"
         style={{
@@ -84,6 +97,15 @@ export function AlertBuilder({ onSubmitted }: { onSubmitted?: () => void } = {})
               >
                 Create Alert
               </span>
+              <button
+                onClick={() => setShowHint((v) => !v)}
+                className="flex items-center justify-center w-4 h-4 rounded-full opacity-40 hover:opacity-80 transition-opacity"
+                style={{ color: "var(--text-muted)" }}
+                aria-label="Alert tips"
+                tabIndex={-1}
+              >
+                <Info size={12} />
+              </button>
             </div>
 
             <input
@@ -116,6 +138,28 @@ export function AlertBuilder({ onSubmitted }: { onSubmitted?: () => void } = {})
           </div>
         </div>
       </div>
+
+      {showHint && (
+        <div
+          className="mt-2 px-4 py-3 rounded-2xl text-xs space-y-2 animate-slide-down"
+          style={{ background: "var(--surface-raised)", border: "1px solid var(--surface-border)" }}
+        >
+          <p className="font-semibold" style={{ color: "var(--text-primary)" }}>Tips for best results</p>
+          <ul className="space-y-1" style={{ color: "var(--text-secondary)" }}>
+            <li>• Include the <span className="font-medium" style={{ color: "var(--text-primary)" }}>stock symbol</span> — e.g. RELIANCE, HDFCBANK, NIFTY50</li>
+            <li>• Describe the <span className="font-medium" style={{ color: "var(--text-primary)" }}>condition</span> — price breakout, volume spike, % drop, MA cross</li>
+            <li>• Add a <span className="font-medium" style={{ color: "var(--text-primary)" }}>threshold</span> where relevant — e.g. "drops 3%", "volume 2× average"</li>
+          </ul>
+          <div className="pt-1 space-y-0.5" style={{ color: "var(--text-muted)", borderTop: "1px solid var(--surface-border)" }}>
+            <p className="font-medium text-[11px] pt-1" style={{ color: "var(--text-secondary)" }}>Examples</p>
+            <p className="font-mono text-[10px]">"HDFCBANK breaks 52-week high with volume confirmation"</p>
+            <p className="font-mono text-[10px]">"INFY drops more than 4% intraday"</p>
+          </div>
+          <p className="text-[10px] pt-0.5" style={{ color: "var(--text-muted)" }}>
+            Desktop notifications fire automatically for all alerts when the app is open — no need to request them separately.
+          </p>
+        </div>
+      )}
 
       {feedback && (
         <div


### PR DESCRIPTION
…builder hint

- Switch agent-create-alert workflow from API key to CLAUDE_CODE_OAUTH_TOKEN to route usage through subscription instead of separate API billing
- Add PATCH /api/alert-requests/[id] endpoint for manual status updates
- Add "Mark Implemented" / "Reject" buttons to dev dashboard alert request rows so merged PRs can be marked without editing data directly
- Add ⓘ info tooltip to AlertBuilder with prompt tips and a note that desktop notifications are automatic for all alerts (no need to request them separately)