### PR TITLE
fix: alert types display, lifecycle sync, and agent registration

### DIFF
--- a/.claude/skills/patch-builder/SKILL.md
+++ b/.claude/skills/patch-builder/SKILL.md
@@ -35,7 +35,12 @@ For every new alert type, create/modify files in this order:
 - Category: `"system"` for automated alerts
 - Include relevant data in `detail` parameter
 
-### 6. Tests (Optional)
+### 6. Register Display Name (`src/components/alerts-section.tsx`)
+- Add the new `alertType` value to the `ALERT_TYPE_LABELS` map
+- Use a concise, human-readable name: `"your-type": "Your Type Name"`
+- This ensures the alert type appears in the dashboard's Alert Types popover
+
+### 7. Tests (Optional)
 - Create test file: `src/lib/__tests__/your-alert.test.ts`
 - Mock Redis: `vi.mock("../redis", () => ({ getRedis: () => null }))`
 - Test the detection function with known inputs/outputs

--- a/.github/workflows/agent-create-alert.yml
+++ b/.github/workflows/agent-create-alert.yml
@@ -53,4 +53,9 @@ jobs:
             or tests at your discretion for verification.
 
             IMPORTANT: Do not modify protected files listed in AGENTS.md.
+
+            IMPORTANT: After implementing the alert, register its display name
+            in the ALERT_TYPE_LABELS map in src/components/alerts-section.tsx.
+            Use the alertType value as key and a concise human-readable name as
+            value (e.g. "200dma": "200 DMA Crossover").
           claude_args: "--allowed-tools Bash Edit Read Write Glob Grep"

--- a/.github/workflows/alert-request-sync.yml
+++ b/.github/workflows/alert-request-sync.yml
@@ -1,0 +1,59 @@
+name: Sync Alert Request Status
+
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  sync-status:
+    if: contains(github.event.issue.labels.*.name, 'agent:create-alert')
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    env:
+      DEPLOY_URL: ${{ secrets.DEPLOY_URL }}
+
+    steps:
+      - name: Resolve status and alert request ID
+        id: resolve
+        if: env.DEPLOY_URL != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issueNumber = context.payload.issue.number;
+
+            // Check if a PR linked to this issue was merged
+            const pulls = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed',
+              per_page: 50,
+            });
+            const merged = pulls.data.some(
+              (pr) => pr.merged_at && pr.body?.includes(`#${issueNumber}`)
+            );
+            const status = merged ? 'implemented' : 'rejected';
+
+            // Fetch alert requests to find the one linked to this issue
+            const res = await fetch(`${process.env.DEPLOY_URL}/api/alert-requests`);
+            if (!res.ok) {
+              core.warning(`Failed to fetch alert requests: ${res.status}`);
+              return;
+            }
+            const requests = await res.json();
+            const target = requests.find((r) => r.githubIssueNumber === issueNumber);
+            if (!target) {
+              core.warning(`No alert request found for issue #${issueNumber}`);
+              return;
+            }
+
+            core.setOutput('status', status);
+            core.setOutput('id', target.id);
+            core.info(`Issue #${issueNumber} → request ${target.id} → ${status}`);
+
+      - name: Update alert request status
+        if: steps.resolve.outputs.id != ''
+        run: |
+          curl -sf -X PATCH "${DEPLOY_URL}/api/alert-requests/${{ steps.resolve.outputs.id }}" \
+            -H "Content-Type: application/json" \
+            -d "{\"status\": \"${{ steps.resolve.outputs.status }}\"}" \
+          || echo "::warning::Failed to update alert request status (API unreachable)"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,8 +38,9 @@ For every new alert type, follow these steps in order:
 4. **Wire into scan** — Ensure the scan pipeline calls your detection logic. Look at how `scanStock()` calls `analyzeBreakout()` as a pattern
 5. **Store alerts** — Use the existing `addAlert()` from `src/lib/store.ts` with appropriate dedup (symbol + alertType + date)
 6. **Log activity** — Call `addActivity()` from `src/lib/activity.ts` when an alert fires
-7. **Test** — Write vitest tests if practical (mock Redis via `vi.mock("./redis")`). Tests are encouraged but not required
-8. **Verify** — Run `npm run typecheck` to confirm no type errors
+7. **Register display name** — Add the new `alertType` value and its human-readable label to `ALERT_TYPE_LABELS` in `src/components/alerts-section.tsx` (e.g. `"200dma": "200 DMA Crossover"`)
+8. **Test** — Write vitest tests if practical (mock Redis via `vi.mock("./redis")`). Tests are encouraged but not required
+9. **Verify** — Run `npm run typecheck` to confirm no type errors
 
 ## PR Format
 
@@ -60,4 +61,5 @@ Body:
 - [ ] `npm run typecheck` passes
 - [ ] New alert type is wired into scan pipeline
 - [ ] Dedup prevents duplicate alerts for same symbol+type+date
+- [ ] Display name added to `ALERT_TYPE_LABELS` in `src/components/alerts-section.tsx`
 ```

--- a/docs/ALERTS.md
+++ b/docs/ALERTS.md
@@ -110,7 +110,11 @@ Same symbol + same alert type + same calendar date = duplicate → skipped.
    }
    ```
 
-6. **Test** (optional but encouraged):
+6. **Register display name** in `src/components/alerts-section.tsx`:
+   - Add to the `ALERT_TYPE_LABELS` map: `"your-new-type": "Your Alert Name"`
+   - This makes the alert type appear in the dashboard's Alert Types popover
+
+7. **Test** (optional but encouraged):
    ```ts
    // src/lib/__tests__/your-alert.test.ts
    import { vi } from "vitest";

--- a/src/components/alerts-section.tsx
+++ b/src/components/alerts-section.tsx
@@ -1,17 +1,18 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import gsap from "gsap";
 import type { Alert, AlertRequest } from "@/lib/types";
 import { AlertBuilder } from "./alert-builder";
 
-/* ── Built-in alert types (pre-date the request system) ────────────── */
+/* ── Known alert-type labels (alertType value → display name) ──────── */
 
-const BUILTIN_ALERT_TYPES = [
-  { id: "true-breakout", name: "True Breakout", status: "active" as const },
-  { id: "low-breakout", name: "Low Breakout", status: "active" as const },
-  { id: "week-high", name: "52 Week High", status: "active" as const },
-];
+const ALERT_TYPE_LABELS: Record<string, string> = {
+  breakout: "True Breakout",
+  "low-breakout": "Low Breakout",
+  "week-high": "52 Week High",
+  // "scan" is intentionally omitted — same logic as breakout, fired during watchlist scans
+};
 
 /* ── Helpers ─────────────────────────────────────────────────────────── */
 
@@ -29,7 +30,6 @@ function deriveAlertName(text: string): string {
 
 /* ── Main Component ─────────────────────────────────────────────────── */
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function AlertsSection({ alerts }: { alerts: Alert[] }) {
   const [alertRequests, setAlertRequests] = useState<AlertRequest[]>([]);
   const [configuredOpen, setConfiguredOpen] = useState(false);
@@ -43,14 +43,39 @@ export function AlertsSection({ alerts }: { alerts: Alert[] }) {
     (r) => r.status !== "implemented" && r.status !== "rejected"
   );
 
+  /* Derive active alert types from fired alerts + known labels */
+  const activeAlertTypes = useMemo(() => {
+    const included = new Set<string>();
+    const types: { id: string; name: string; status: "active" }[] = [];
+
+    // Always include known label entries (even if no alerts fired yet)
+    for (const [id, name] of Object.entries(ALERT_TYPE_LABELS)) {
+      included.add(id);
+      types.push({ id, name, status: "active" as const });
+    }
+
+    // Discover any NEW alert types from actual fired alerts
+    for (const alert of alerts) {
+      const t = alert.alertType;
+      if (!t || t === "scan" || included.has(t)) continue;
+      included.add(t);
+      const name = t.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+      types.push({ id: t, name, status: "active" as const });
+    }
+
+    return types;
+  }, [alerts]);
+
   const configuredAlertTypes = [
-    ...BUILTIN_ALERT_TYPES,
+    ...activeAlertTypes,
+    // "implemented" requests are already represented via ALERT_TYPE_LABELS / alert discovery,
+    // so only show pending/in-progress requests here to avoid duplicates.
     ...alertRequests
-      .filter((r) => r.status !== "rejected")
+      .filter((r) => r.status !== "rejected" && r.status !== "implemented")
       .map((r) => ({
         id: r.id,
         name: deriveAlertName(r.text),
-        status: r.status === "implemented" ? ("active" as const) : ("building" as const),
+        status: "building" as const,
       })),
   ];
 
@@ -191,10 +216,10 @@ export function AlertsSection({ alerts }: { alerts: Alert[] }) {
               {/* Configured types popover */}
               <div
                 ref={configuredBubbleRef}
-                className="absolute right-0 top-full mt-2 z-40 w-[210px] overflow-hidden rounded-xl bg-surface-overlay ring-1 ring-surface-border-bright/60 shadow-2xl shadow-black/60"
+                className="absolute right-0 top-full mt-2 z-40 w-[210px] rounded-xl bg-surface-overlay ring-1 ring-surface-border-bright/60 shadow-2xl shadow-black/60"
                 style={{ opacity: 0, visibility: "hidden" }}
               >
-                <div className="px-3 py-2.5 space-y-1">
+                <div className="px-3 py-2.5 space-y-1 max-h-[280px] overflow-y-auto">
                   <p className="text-[9px] font-bold uppercase tracking-wider text-text-muted mb-1.5">Alert Types</p>
                   {configuredAlertTypes.map((type) => (
                     <div key={type.id} className="flex items-center gap-2 py-1">


### PR DESCRIPTION
## Summary

- **Bug fix**: Alert types popover now derives the list dynamically from fired alerts + `ALERT_TYPE_LABELS` map, so newly implemented alert types (like 200 DMA) appear automatically without manual hardcoding
- **Bug fix**: `overflow-hidden` removed from popover outer container; inner div is now `max-h-[280px] overflow-y-auto` — prevents clipping when more than 3 types are listed
- **Bug fix**: `implemented` alert requests excluded from the in-progress list to avoid duplicate entries when a type appears in both `ALERT_TYPE_LABELS` and the request list
- **New**: `alert-request-sync` workflow — when a `agent:create-alert` issue is closed, automatically marks the linked alert request as `implemented` (if PR was merged) or `rejected` (if closed without merge), removing it from the dashboard list
- **New**: Agent instructions updated across `AGENTS.md`, `patch-builder` skill, `docs/ALERTS.md`, and `agent-create-alert` workflow to require registering a display name in `ALERT_TYPE_LABELS` as part of every new alert implementation

## Setup required

Add a `DEPLOY_URL` repository secret (Settings → Secrets → Actions) with your deployed app URL (e.g. `https://your-app.vercel.app`) to enable the sync workflow to call `PATCH /api/alert-requests/:id` on issue close.

## Test plan

- [ ] Alert types popover shows all types including newly implemented ones
- [ ] Closing a `agent:create-alert` issue without merging removes it from the dashboard list
- [ ] Merging the PR then closing the issue marks it as implemented (green ACTIVE)
- [ ] No duplicate entries when an alert type is both in `ALERT_TYPE_LABELS` and the request list

🤖 Generated with [Claude Code](https://claude.com/claude-code)