### PR TITLE
[codex] Fix Nifty 50 live data resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Browser notifications fire the instant an alert triggers, with a 5-minute cooldo
 
 ### Prerequisites
 
-- Node.js 18+
+- Node.js 20+
 - npm
 
 ### Setup

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,7 +5,7 @@
 - **Framework**: Next.js 14 (App Router) + React 18
 - **Styling**: Tailwind CSS 3.4 + GSAP animations
 - **Persistence**: Upstash Redis (primary) + filesystem JSON fallback (local dev)
-- **NSE Data**: `stock-nse-india` v1.3.0 NPM package
+- **NSE Data**: `stock-nse-india` v1.4.0 NPM package (Node.js 20+)
 - **Auth**: HMAC-SHA256 session cookies
 - **Validation**: Zod
 - **Testing**: Vitest + Testing Library
@@ -52,7 +52,7 @@ src/
     ├── activity.ts         # Audit trail (ring buffer, max 200 events)
     ├── alert-requests.ts   # AI alert request storage (ring buffer, max 50)
     ├── api-stats.ts        # API call tracking + Redis persistence
-    ├── baselines.ts        # 5-day rolling baselines (in-memory cache)
+    ├── baselines.ts        # 5-day rolling baselines (in-memory + Redis cache)
     ├── github.ts           # GitHub Issue creation (for alert builder)
     ├── lockdown.ts         # Lockdown + session epoch (edge-compatible)
     ├── logger.ts           # Structured logger
@@ -93,6 +93,9 @@ All stores follow the same pattern: Redis primary, filesystem JSON fallback.
 | `nse:api-stats` | api-stats.ts | Hash — apiCalls, cacheHits, method breakdowns |
 | `nse:security` | lockdown.ts | SecurityState (epoch + lockdown) |
 | `nse:alert-requests` | alert-requests.ts | AlertRequest[] (ring buffer, max 50) |
+| `nse:nifty50Snapshot` | nse-client.ts | Fresh shared Nifty 50 snapshot (15-minute TTL) |
+| `nse:nifty50Snapshot:lastGood` | nse-client.ts | Bounded last-good Nifty 50 snapshot fallback (5-day TTL, returned stale) |
+| `nse:baseline:{date}:{symbol}` | baselines.ts | Shared per-symbol baseline cache (36-hour TTL) |
 
 Filesystem fallback files (under `data/`):
 - `data/state.json` — watchlist, alerts, scan results
@@ -104,10 +107,10 @@ Filesystem fallback files (under `data/`):
 | Data | TTL | Scope |
 |------|-----|-------|
 | Historical prices | 1 day (IST date) | Per-instance (in-memory Map) |
-| Nifty 50 snapshot | 3 minutes | Per-instance |
+| Nifty 50 snapshot | 3 minutes in-memory, 15 minutes shared Redis, 5 days last-good Redis | Per-instance + Redis shared on Upstash; last-good reuse is returned stale |
 | Nifty 50 index | 15 seconds | Per-instance |
 | Market status | 1 minute | Per-instance |
-| 5-day baselines | 1 day (IST date) | Per-instance |
+| 5-day baselines | 1 day (IST date) in-memory, 36 hours shared Redis | Per-instance + Redis shared on Upstash |
 | API stats | Flushed on each /api/state poll | Redis (cross-instance) |
 
 Outside extended hours (before 09:00 or after 16:00 IST), NSE API calls are skipped entirely — cached data is served.

--- a/docs/api-capability-map.md
+++ b/docs/api-capability-map.md
@@ -1,6 +1,6 @@
 # NSE API Capability Map
 
-Data source: `stock-nse-india` v1.3.0 (NPM package wrapping NSE India's unofficial API).
+Data source: `stock-nse-india` v1.4.0 (NPM package wrapping NSE India's unofficial API; requires Node.js 20+).
 
 ## Currently Used Methods
 

--- a/docs/system-design-context.md
+++ b/docs/system-design-context.md
@@ -12,7 +12,7 @@ A personal, single-user stock breakout detection dashboard for the National Stoc
 | Framework | Next.js 14 (App Router) + React 18 |
 | Styling | Tailwind CSS 3.4 + GSAP animations |
 | Persistence | Upstash Redis (primary) + filesystem JSON (local fallback) |
-| External data | `stock-nse-india` NPM package (wraps NSE India public API) |
+| External data | `stock-nse-india` v1.4.0 NPM package (wraps NSE India public API; Node.js 20+) |
 | Auth | HMAC-SHA256 session cookies with epoch rotation |
 | Validation | Zod on all API inputs |
 | Testing | Vitest (node env) |
@@ -38,7 +38,7 @@ NSE India API  +  Upstash Redis
 |--------|---------------|
 | `nse-client.ts` | NSE API wrapper with in-memory caching, retries, singleton pattern |
 | `scanner.ts` | Breakout detection (`analyzeBreakout()`) |
-| `baselines.ts` | 5-day rolling baselines (in-memory, per IST date) |
+| `baselines.ts` | 5-day rolling baselines (in-memory + Redis, per IST date) |
 | `store.ts` | Watchlist/alert/scan result CRUD against Redis or filesystem |
 | `activity.ts` | Audit trail ring buffer (max 200 events) |
 | `market-hours.ts` | IST market hours gating logic |
@@ -73,6 +73,9 @@ User triggers /api/scan →
 | `nse:activity` | Ring buffer (max 200 events) |
 | `nse:api-stats` | Hash of call counts / cache hits |
 | `nse:security` | Epoch + lockdown flag |
+| `nse:nifty50Snapshot` | Fresh shared Nifty 50 snapshot (15-minute TTL) |
+| `nse:nifty50Snapshot:lastGood` | Bounded last-good Nifty 50 snapshot fallback (5-day TTL, returned stale) |
+| `nse:baseline:{date}:{symbol}` | Shared per-symbol baseline cache (36-hour TTL) |
 
 Filesystem fallback lives in `data/*.json`. On Vercel (read-only FS), Redis is required.
 
@@ -83,10 +86,10 @@ Filesystem fallback lives in `data/*.json`. On Vercel (read-only FS), Redis is r
 | Data | TTL | Scope |
 |------|-----|-------|
 | Historical prices | 1 day (IST date) | Per-instance in-memory Map |
-| Nifty 50 snapshot | 3 minutes | Per-instance |
+| Nifty 50 snapshot | 3 minutes in-memory, 15 minutes shared Redis, 5 days last-good Redis | Per-instance + Redis shared on Upstash; last-good reuse is returned stale |
 | Nifty 50 index value | 15 seconds | Per-instance |
 | Market status | 1 minute | Per-instance |
-| 5-day baselines | 1 day (IST date) | Per-instance |
+| 5-day baselines | 1 day (IST date) in-memory, 36 hours shared Redis | Per-instance + Redis shared on Upstash |
 | API stats | Flushed on each `/api/state` poll | Redis (cross-instance) |
 
 Outside extended hours (before 09:00 / after 16:00 IST), all NSE API calls are skipped entirely.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,15 @@
 {
   "name": "nifty-stock-scanner",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nifty-stock-scanner",
-      "version": "1.0.0",
+      "version": "1.1.0",
+      "engines": {
+        "node": ">=20"
+      },
       "dependencies": {
         "@upstash/redis": "^1.36.2",
         "@vercel/speed-insights": "^1.3.1",
@@ -16,7 +19,7 @@
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
         "redis": "^5.11.0",
-        "stock-nse-india": "^1.3.0",
+        "stock-nse-india": "1.4.0",
         "zod": "^3.23.0"
       },
       "devDependencies": {
@@ -2947,7 +2950,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -3410,6 +3412,60 @@
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios-cookiejar-support": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/axios-cookiejar-support/-/axios-cookiejar-support-5.0.5.tgz",
+      "integrity": "sha512-jJG+p7JnOYxkVrYkCDKBrLqUmcpwHZTNQrEcIEKr5qe7YVTyPAD9nCsi1cO5LDmQpQApfS430czO+oceI3g/3g==",
+      "license": "MIT",
+      "dependencies": {
+        "http-cookie-agent": "^6.0.8"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/3846masa"
+      },
+      "peerDependencies": {
+        "axios": ">=0.20.0",
+        "tough-cookie": ">=4.0.0"
+      }
+    },
+    "node_modules/axios-cookiejar-support/node_modules/http-cookie-agent": {
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-6.0.8.tgz",
+      "integrity": "sha512-qnYh3yLSr2jBsTYkw11elq+T361uKAJaZ2dR4cfYZChw1dt9uL5t3zSUwehoqqVb4oldk1BpkXKm2oat8zV+oA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/3846masa"
+      },
+      "peerDependencies": {
+        "tough-cookie": "^4.0.0 || ^5.0.0",
+        "undici": "^5.11.0 || ^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "undici": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/axios-cookiejar-support/node_modules/undici": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/balanced-match": {
@@ -4383,6 +4439,18 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {
@@ -7534,9 +7602,9 @@
       "license": "MIT"
     },
     "node_modules/stock-nse-india": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/stock-nse-india/-/stock-nse-india-1.3.0.tgz",
-      "integrity": "sha512-pfxzhxV8T9KUf1RWKRy5nEKEDD+K8fAO3PRR41IysUlvgvOwBPJMV1jZp6PgteJZvsfhNf/Yl22uaMIYixmXsw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/stock-nse-india/-/stock-nse-india-1.4.0.tgz",
+      "integrity": "sha512-L98OucnCW+PSz5XN/mxDDdBoeLVr2EpQxyIA9uTqRfiF96WMi+7JhX54aqgjImoYkfz5l2KVtGD6PEVnZ4AwfQ==",
       "license": "MIT",
       "dependencies": {
         "@graphql-tools/graphql-file-loader": "^7.5.13",
@@ -7549,9 +7617,11 @@
         "apollo-server-express": "^3.10.0",
         "asciichart": "^1.5.25",
         "axios": "^1.4.0",
+        "axios-cookiejar-support": "^5.0.5",
         "chalk": "^4.1.2",
         "cheerio": "1.0.0-rc.10",
         "cors": "^2.8.5",
+        "dotenv": "^17.4.2",
         "express": "^4.18.2",
         "graphql": "^16.6.0",
         "indicatorts": "^2.2.2",
@@ -7563,6 +7633,7 @@
         "ora": "^5.4.1",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^4.6.3",
+        "tough-cookie": "^5.1.2",
         "user-agents": "^1.0.104",
         "yargs": "^17.7.2"
       },
@@ -7570,7 +7641,7 @@
         "nseindia": "build/cli/index.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/strict-url-sanitise": {
@@ -8022,7 +8093,6 @@
       "version": "6.1.86",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
       "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tldts-core": "^6.1.86"
@@ -8035,7 +8105,6 @@
       "version": "6.1.86",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
       "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/to-buffer": {
@@ -8077,7 +8146,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
       "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^6.1.32"

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "nifty-stock-scanner",
   "version": "1.1.0",
   "private": true,
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",
@@ -20,7 +23,7 @@
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
     "redis": "^5.11.0",
-    "stock-nse-india": "^1.3.0",
+    "stock-nse-india": "1.4.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/src/app/api/nifty50/route.spec.ts
+++ b/src/app/api/nifty50/route.spec.ts
@@ -63,6 +63,7 @@ describe("Nifty50 route contracts", () => {
       snapshotFetchSuccess: true,
       snapshotFetchCount: 1,
       snapshotFailCount: 0,
+      snapshotSource: "nse-index",
     });
     mocks.updateNifty50PersistentStats.mockResolvedValue(undefined);
     mocks.getBaselineStats.mockReturnValue({
@@ -176,6 +177,109 @@ describe("Nifty50 route contracts", () => {
     expect(stale.baselineUnavailable).toBe(false);
     expect(stale.possibleBreakout).toBe(true);
 
+    expect(mocks.addAlert).not.toHaveBeenCalled();
+  });
+
+  test("uses cached baselines only for live intraday fallback snapshots", async () => {
+    // Contract: live intraday fallback must return the table without cold-starting
+    // 50 historical baseline requests inside the production route budget.
+    mocks.getNifty50Snapshot.mockResolvedValue(
+      makeSnapshot({
+        source: "nse-charting-intraday",
+        stocks: [
+          makeSnapshotStock({ symbol: "TCS", name: "TCS", lastPrice: 100 }),
+          makeSnapshotStock({ symbol: "ITC", name: "ITC", lastPrice: 200 }),
+        ],
+      }),
+    );
+    mocks.getBaselines.mockResolvedValue(new Map());
+
+    const response = await GET();
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.snapshot.source).toBe("nse-charting-intraday");
+    expect(mocks.getBaselines).toHaveBeenCalledWith(["TCS", "ITC"], { maxToFetch: 0 });
+    expect(json.discoveries).toHaveLength(2);
+    expect(json.discoveries.every((d: { baselineUnavailable: boolean }) => d.baselineUnavailable)).toBe(true);
+    expect(mocks.addAlert).not.toHaveBeenCalled();
+  });
+
+  test("does not confirm breakout signals from cached baselines on fallback snapshots", async () => {
+    mocks.getNifty50Snapshot.mockResolvedValue(
+      makeSnapshot({
+        source: "nse-charting-intraday",
+        stocks: [
+          makeSnapshotStock({
+            symbol: "TCS",
+            name: "TCS",
+            dayHigh: 120,
+            totalTradedVolume: 3100,
+            lastPrice: 118,
+          }),
+        ],
+      }),
+    );
+    mocks.getBaselines.mockResolvedValue(
+      new Map([["TCS", makeBaseline("TCS", { maxHigh5d: 100, maxVolume5d: 1000 })]]),
+    );
+
+    const response = await GET();
+    const json = await response.json();
+    const tcs = json.discoveries.find((d: { symbol: string }) => d.symbol === "TCS");
+
+    expect(response.status).toBe(200);
+    expect(tcs.breakout).toBe(false);
+    expect(tcs.highBreak).toBe(false);
+    expect(tcs.volumeBreak).toBe(false);
+    expect(tcs.baselineUnavailable).toBe(false);
+    expect(tcs.possibleBreakout).toBe(true);
+    expect(mocks.addAlert).not.toHaveBeenCalled();
+    expect(mocks.addActivity).not.toHaveBeenCalledWith(
+      "system",
+      "nifty50-discovery",
+      expect.any(String),
+      expect.any(Object),
+    );
+  });
+
+  test("does not mark ordinary fallback rows as possible breakouts", async () => {
+    mocks.getNifty50Snapshot.mockResolvedValue(
+      makeSnapshot({
+        source: "nse-charting-intraday",
+        stocks: [
+          makeSnapshotStock({
+            symbol: "ITC",
+            name: "ITC",
+            dayHigh: 95,
+            dayLow: 91,
+            totalTradedVolume: 100,
+            lastPrice: 94,
+          }),
+        ],
+      }),
+    );
+    mocks.getBaselines.mockResolvedValue(
+      new Map([
+        [
+          "ITC",
+          makeBaseline("ITC", {
+            maxHigh5d: 100,
+            maxVolume5d: 1000,
+            minLow10d: 90,
+            maxVolume10d: 2000,
+          }),
+        ],
+      ]),
+    );
+
+    const response = await GET();
+    const json = await response.json();
+    const itc = json.discoveries.find((d: { symbol: string }) => d.symbol === "ITC");
+
+    expect(response.status).toBe(200);
+    expect(itc.breakout).toBe(false);
+    expect(itc.possibleBreakout).toBe(false);
     expect(mocks.addAlert).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/nifty50/route.ts
+++ b/src/app/api/nifty50/route.ts
@@ -8,10 +8,15 @@ import type {
   BreakoutDiscovery,
   Nifty50TableResponse,
   Alert,
+  Nifty50StockRow,
+  StockBaseline,
 } from "@/lib/types";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
+
+const PRIMARY_SOURCE_BASELINE_FETCH_LIMIT = 5;
+const FALLBACK_SOURCE_BASELINE_FETCH_LIMIT = 0;
 
 function todayIST(): string {
   return new Date(
@@ -19,6 +24,14 @@ function todayIST(): string {
   )
     .toISOString()
     .slice(0, 10);
+}
+
+function isPotentialSignal(stock: Nifty50StockRow, baseline: StockBaseline): boolean {
+  const highBreak = stock.dayHigh > baseline.maxHigh5d;
+  const volumeBreak = stock.totalTradedVolume >= baseline.maxVolume5d * 3;
+  const lowBreak = stock.dayLow < baseline.minLow10d;
+  const lowVolumeBreak = stock.totalTradedVolume > baseline.maxVolume10d;
+  return (highBreak && volumeBreak) || (lowBreak && lowVolumeBreak);
 }
 
 export async function GET() {
@@ -34,10 +47,16 @@ export async function GET() {
     const watchlistSymbols = watchlist.map((s) => s.symbol);
     const closeWatchSymbols = closeWatchStocks.map((s) => s.symbol);
     const watchlistSet = new Set(watchlistSymbols);
+    const isPrimarySource = snapshot.source === "nse-index";
 
-    // Compute baselines for all snapshot symbols
+    // Use cached baselines for fallback sources and hydrate only a small slice for
+    // the primary path. Cold-starting all 50 can exceed production duration.
     const snapshotSymbols = snapshot.stocks.map((s) => s.symbol);
-    const baselines = await getBaselines(snapshotSymbols);
+    const baselineFetchLimit =
+      snapshot.source === "nse-index"
+        ? PRIMARY_SOURCE_BASELINE_FETCH_LIMIT
+        : FALLBACK_SOURCE_BASELINE_FETCH_LIMIT;
+    const baselines = await getBaselines(snapshotSymbols, { maxToFetch: baselineFetchLimit });
     const baseStats = getBaselineStats();
 
     // Build breakout discoveries for stocks NOT in the watchlist
@@ -50,7 +69,7 @@ export async function GET() {
       if (watchlistSet.has(stock.symbol)) continue;
 
       // 52-week high alert (no baseline required — data comes from snapshot)
-      if (snapshot.fetchSuccess && stock.yearHigh > 0 && stock.dayHigh >= stock.yearHigh) {
+      if (isPrimarySource && snapshot.fetchSuccess && stock.yearHigh > 0 && stock.dayHigh >= stock.yearHigh) {
         const weekHighAlert: Alert = {
           id: `${stock.symbol}-nifty50-week-high-${today}`,
           symbol: stock.symbol,
@@ -103,7 +122,8 @@ export async function GET() {
         continue;
       }
 
-      // If snapshot fetch failed (stale data), mark as possibleBreakout
+      // If snapshot freshness/source trust is degraded, only surface plausible
+      // candidates as possible; never mark them as confirmed signals.
       if (!snapshot.fetchSuccess) {
         discoveries.push({
           symbol: stock.symbol,
@@ -114,7 +134,22 @@ export async function GET() {
           highBreakPercent: 0,
           volumeBreakPercent: 0,
           baselineUnavailable: false,
-          possibleBreakout: true,
+          possibleBreakout: isPotentialSignal(stock, baseline),
+        });
+        continue;
+      }
+
+      if (!isPrimarySource) {
+        discoveries.push({
+          symbol: stock.symbol,
+          name: stock.name,
+          breakout: false,
+          highBreak: false,
+          volumeBreak: false,
+          highBreakPercent: 0,
+          volumeBreakPercent: 0,
+          baselineUnavailable: false,
+          possibleBreakout: isPotentialSignal(stock, baseline),
         });
         continue;
       }
@@ -144,7 +179,7 @@ export async function GET() {
       });
 
       // Fire alert for confirmed breakouts (dedup by symbol + alertType + date)
-      if (breakout) {
+      if (isPrimarySource && breakout) {
         const alertId = `${stock.symbol}-nifty50-breakout-${today}`;
         const alert: Alert = {
           id: alertId,
@@ -193,7 +228,7 @@ export async function GET() {
       const lowBreak = stock.dayLow < baseline.minLow10d;
       const volumeBreak10d = stock.totalTradedVolume > baseline.maxVolume10d;
 
-      if (lowBreak && volumeBreak10d) {
+      if (isPrimarySource && lowBreak && volumeBreak10d) {
         const lowBreakPct = baseline.minLow10d > 0
           ? Math.round(((baseline.minLow10d - stock.dayLow) / baseline.minLow10d) * 10000) / 100
           : 0;
@@ -277,6 +312,7 @@ export async function GET() {
             highBreakSymbols,
             volBreakSymbols,
             snapshotStale: snapshot.stale,
+            snapshotSource: snapshot.source,
             alertsCreated: newAlerts.length,
           },
         },
@@ -290,6 +326,7 @@ export async function GET() {
       snapshotFetchSuccess: snapshot.fetchSuccess,
       snapshotFetchCount: prevStats.snapshotFetchCount + (snapshot.fetchSuccess ? 1 : 0),
       snapshotFailCount: prevStats.snapshotFailCount + (snapshot.fetchSuccess ? 0 : 1),
+      snapshotSource: snapshot.source,
     });
 
     const response: Nifty50TableResponse = {
@@ -314,6 +351,8 @@ export async function GET() {
         breakoutCount,
         fetchSuccess: snapshot.fetchSuccess,
         stale: snapshot.stale,
+        source: snapshot.source,
+        baselineFetchLimit,
       },
       "Nifty50 Table API",
     );

--- a/src/app/api/state/route.spec.ts
+++ b/src/app/api/state/route.spec.ts
@@ -89,6 +89,7 @@ describe("Dev state route contracts", () => {
       snapshotFetchSuccess: true,
       snapshotFetchCount: 7,
       snapshotFailCount: 1,
+      snapshotSource: "nse-charting-intraday",
     });
     mocks.getBaselineStats.mockReturnValue({
       available: 48,
@@ -120,6 +121,7 @@ describe("Dev state route contracts", () => {
       snapshotFetchSuccess: true,
       snapshotFetchCount: 7,
       snapshotFailCount: 1,
+      snapshotSource: "nse-charting-intraday",
     });
     expect(json.nifty50Stats.baselines).toMatchObject({
       available: 48,

--- a/src/app/dev/page.tsx
+++ b/src/app/dev/page.tsx
@@ -26,6 +26,7 @@ interface Nifty50StatsData {
   snapshotFetchSuccess: boolean;
   snapshotFetchCount: number;
   snapshotFailCount: number;
+  snapshotSource: "nse-index" | "nse-charting-intraday" | "unavailable";
   baselines: {
     available: number;
     missing: number;
@@ -41,6 +42,7 @@ interface CacheLayersData {
     snapshotFetchSuccess: boolean;
     snapshotFetchCount: number;
     snapshotFailCount: number;
+    snapshotSource: "nse-index" | "nse-charting-intraday" | "unavailable";
     scope?: string;
   };
   apiThrottle: {
@@ -885,6 +887,11 @@ export default function DevDashboard() {
                 const fetchOk = n.snapshotFetchSuccess;
                 const totalFetches = n.snapshotFetchCount + n.snapshotFailCount;
                 const successRate = totalFetches > 0 ? Math.round((n.snapshotFetchCount / totalFetches) * 100) : 0;
+                const sourceLabel = n.snapshotSource === 'nse-index'
+                  ? 'NSE index'
+                  : n.snapshotSource === 'nse-charting-intraday'
+                    ? 'Charting fallback'
+                    : 'Unavailable';
                 return (
                   <CollapsibleSection
                     title="Nifty 50 Table"
@@ -906,7 +913,7 @@ export default function DevDashboard() {
                           <span className="text-xs font-bold tabular-nums text-red-400">{n.snapshotFailCount}</span>
                           <span className="text-[8px] text-text-muted">fail</span>
                         </div>
-                        <p className="text-[8px] text-text-muted/40 mt-0.5">{successRate}% success</p>
+                        <p className="text-[8px] text-text-muted/40 mt-0.5">{successRate}% success - {sourceLabel}</p>
                       </div>
                       <div>
                         <p className="text-[9px] text-text-muted font-semibold mb-1">Baselines</p>
@@ -956,6 +963,9 @@ export default function DevDashboard() {
                           <span className={`h-1.5 w-1.5 rounded-full ${cl.snapshot.snapshotFetchSuccess ? 'bg-emerald-400' : 'bg-amber-400'}`} />
                           <span className="text-[10px] font-semibold text-emerald-400">Snapshot</span>
                           <ScopeBadge scope={cl.snapshot.scope} />
+                          {cl.snapshot.snapshotSource === 'nse-charting-intraday' && (
+                            <span className="rounded bg-amber-500/10 px-1 text-[8px] font-semibold text-amber-400">Fallback</span>
+                          )}
                         </div>
                         <div className="flex items-baseline gap-1.5">
                           <span className="text-xs font-bold tabular-nums">{cl.snapshot.snapshotFetchCount}</span>

--- a/src/components/nifty50-table.tsx
+++ b/src/components/nifty50-table.tsx
@@ -220,6 +220,8 @@ export function Nifty50Table() {
   const baselineUnavailableCount = discoveries.filter((d) => d.baselineUnavailable).length;
   const isStale = data?.snapshot.stale ?? false;
   const fetchSuccess = data?.snapshot.fetchSuccess ?? true;
+  const snapshotSource = data?.snapshot.source ?? "nse-index";
+  const liveLabel = snapshotSource === "nse-charting-intraday" ? "Live intraday" : "Live";
 
   const gainers = data ? data.snapshot.stocks.filter((s) => s.pChange > 0).length : 0;
   const losers = data ? data.snapshot.stocks.filter((s) => s.pChange < 0).length : 0;
@@ -294,7 +296,7 @@ export function Nifty50Table() {
                     <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-accent opacity-75" />
                     <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-accent" />
                   </span>
-                  Live
+                  {liveLabel}
                 </span>
               )}
               {!marketLive && hasFetchedRef.current && (
@@ -407,7 +409,7 @@ export function Nifty50Table() {
                 <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
                   <path d="M12 9v4M12 17h.01" />
                 </svg>
-                {possibleCount} possible (stale data)
+                {possibleCount} possible (unconfirmed)
               </span>
             )}
             {baselineUnavailableCount > 0 && (

--- a/src/lib/baselines.spec.ts
+++ b/src/lib/baselines.spec.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { StockBaseline } from "./types";
+
+const { getHistoricalDataMock, getRedisMock, loggerMock } = vi.hoisted(() => ({
+  getHistoricalDataMock: vi.fn(),
+  getRedisMock: vi.fn(),
+  loggerMock: {
+    api: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock("./nse-client", () => ({
+  getHistoricalData: getHistoricalDataMock,
+}));
+
+vi.mock("./redis", () => ({
+  getRedis: getRedisMock,
+}));
+
+vi.mock("./logger", () => ({
+  logger: loggerMock,
+}));
+
+function makeBaseline(symbol = "TCS"): StockBaseline {
+  return {
+    symbol,
+    maxHigh5d: 110,
+    maxVolume5d: 1200,
+    minLow10d: 90,
+    maxVolume10d: 2000,
+    computedDate: "2025-01-06",
+  };
+}
+
+describe("Baseline shared cache", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-01-06T10:30:00.000Z"));
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("returns Upstash-cached baselines when fetch hydration is disabled", async () => {
+    const baseline = makeBaseline("TCS");
+    const redis = {
+      get: vi.fn(async (key: string) =>
+        key === "nse:baseline:2025-01-06:TCS" ? baseline : null,
+      ),
+      set: vi.fn(),
+    };
+    getRedisMock.mockReturnValue(redis);
+
+    const { getBaselines } = await import("./baselines");
+    const result = await getBaselines(["TCS"], { maxToFetch: 0 });
+
+    expect(result.get("TCS")).toEqual(baseline);
+    expect(getHistoricalDataMock).not.toHaveBeenCalled();
+    expect(redis.set).not.toHaveBeenCalled();
+  });
+
+  test("writes newly computed baselines to Upstash", async () => {
+    const redis = {
+      get: vi.fn(async () => null),
+      set: vi.fn(),
+    };
+    getRedisMock.mockReturnValue(redis);
+    getHistoricalDataMock.mockResolvedValue([
+      { date: "2025-01-01", high: 100, low: 90, open: 95, close: 98, volume: 1000 },
+      { date: "2025-01-02", high: 101, low: 91, open: 96, close: 99, volume: 1100 },
+      { date: "2025-01-03", high: 102, low: 92, open: 97, close: 100, volume: 1200 },
+      { date: "2025-01-04", high: 103, low: 93, open: 98, close: 101, volume: 1300 },
+      { date: "2025-01-05", high: 104, low: 94, open: 99, close: 102, volume: 1400 },
+    ]);
+
+    const { getBaseline } = await import("./baselines");
+    const baseline = await getBaseline("tcs");
+
+    expect(baseline).toMatchObject({
+      symbol: "TCS",
+      maxHigh5d: 104,
+      maxVolume5d: 1200,
+      minLow10d: 90,
+      maxVolume10d: 1400,
+      computedDate: "2025-01-06",
+    });
+    expect(redis.set).toHaveBeenCalledWith(
+      "nse:baseline:2025-01-06:TCS",
+      baseline,
+      { ex: 129600 },
+    );
+  });
+});

--- a/src/lib/baselines.ts
+++ b/src/lib/baselines.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import { getHistoricalData } from "./nse-client";
 import { logger } from "./logger";
+import { getRedis } from "./redis";
 import type { StockBaseline } from "./types";
 
 /* ── Baseline Cache ───────────────────────────────────────────────────
@@ -13,6 +14,7 @@ import type { StockBaseline } from "./types";
  * ──────────────────────────────────────────────────────────────────── */
 
 const LOOKBACK_DAYS = 5;
+const BASELINE_SHARED_CACHE_TTL_SECONDS = 36 * 60 * 60;
 const baselineCache = new Map<string, StockBaseline>();
 
 function todayIST(): string {
@@ -23,22 +25,75 @@ function todayIST(): string {
     .slice(0, 10);
 }
 
+function baselineSharedCacheKey(symbol: string, date: string): string {
+  return `nse:baseline:${date}:${symbol.toUpperCase()}`;
+}
+
+async function readSharedBaseline(
+  symbol: string,
+  date: string,
+): Promise<StockBaseline | null> {
+  const r = getRedis();
+  if (!r) return null;
+
+  try {
+    const baseline = await r.get<StockBaseline>(baselineSharedCacheKey(symbol, date));
+    if (!baseline || baseline.computedDate !== date || baseline.symbol !== symbol.toUpperCase()) {
+      return null;
+    }
+    baselineCache.set(symbol.toUpperCase(), baseline);
+    return baseline;
+  } catch (error) {
+    logger.warn(
+      `Baseline shared cache read failed: ${symbol}`,
+      { error, symbol },
+      "Baseline Service",
+    );
+    return null;
+  }
+}
+
+async function writeSharedBaseline(baseline: StockBaseline): Promise<void> {
+  const r = getRedis();
+  if (!r) return;
+
+  try {
+    await r.set(
+      baselineSharedCacheKey(baseline.symbol, baseline.computedDate),
+      baseline,
+      { ex: BASELINE_SHARED_CACHE_TTL_SECONDS },
+    );
+  } catch (error) {
+    logger.warn(
+      `Baseline shared cache write failed: ${baseline.symbol}`,
+      { error, symbol: baseline.symbol },
+      "Baseline Service",
+    );
+  }
+}
+
 /** Get baseline for a single symbol. Returns null if historical data is insufficient. */
 export async function getBaseline(symbol: string): Promise<StockBaseline | null> {
+  const normalizedSymbol = symbol.toUpperCase();
   const today = todayIST();
-  const cached = baselineCache.get(symbol);
+  const cached = baselineCache.get(normalizedSymbol);
 
   if (cached && cached.computedDate === today) {
     return cached;
   }
 
+  const shared = await readSharedBaseline(normalizedSymbol, today);
+  if (shared) {
+    return shared;
+  }
+
   try {
-    const historical = await getHistoricalData(symbol, 25);
+    const historical = await getHistoricalData(normalizedSymbol, 25);
 
     if (historical.length < LOOKBACK_DAYS) {
       logger.debug(
-        `Baseline: insufficient data for ${symbol} (${historical.length} days)`,
-        { symbol, daysAvailable: historical.length },
+        `Baseline: insufficient data for ${normalizedSymbol} (${historical.length} days)`,
+        { symbol: normalizedSymbol, daysAvailable: historical.length },
         "Baseline Service",
       );
       return null;
@@ -52,7 +107,7 @@ export async function getBaseline(symbol: string): Promise<StockBaseline | null>
       : historical;
 
     const baseline: StockBaseline = {
-      symbol,
+      symbol: normalizedSymbol,
       maxHigh5d: Math.max(...recentDays.map((d) => d.high)),
       maxVolume5d:
         recentDays.reduce((sum, d) => sum + d.volume, 0) / recentDays.length,
@@ -61,21 +116,25 @@ export async function getBaseline(symbol: string): Promise<StockBaseline | null>
       computedDate: today,
     };
 
-    baselineCache.set(symbol, baseline);
+    baselineCache.set(normalizedSymbol, baseline);
+    await writeSharedBaseline(baseline);
     return baseline;
   } catch (error) {
     logger.error(
-      `Baseline computation failed: ${symbol}`,
+      `Baseline computation failed: ${normalizedSymbol}`,
       { error },
       "Baseline Service",
-      `Could not compute the 5-day baseline for ${symbol}. Breakout detection will be unavailable for this stock.`,
+      `Could not compute the 5-day baseline for ${normalizedSymbol}. Breakout detection will be unavailable for this stock.`,
     );
     return null;
   }
 }
 
 /** Batch-fetch baselines for multiple symbols. Non-blocking — failures for individual symbols are silently handled. */
-export async function getBaselines(symbols: string[]): Promise<Map<string, StockBaseline>> {
+export async function getBaselines(
+  symbols: string[],
+  options: { maxToFetch?: number } = {},
+): Promise<Map<string, StockBaseline>> {
   const today = todayIST();
 
   // Split into cached vs need-fetch
@@ -83,11 +142,12 @@ export async function getBaselines(symbols: string[]): Promise<Map<string, Stock
   const toFetch: string[] = [];
 
   for (const sym of symbols) {
-    const cached = baselineCache.get(sym);
+    const normalizedSymbol = sym.toUpperCase();
+    const cached = baselineCache.get(normalizedSymbol);
     if (cached && cached.computedDate === today) {
-      results.set(sym, cached);
+      results.set(normalizedSymbol, cached);
     } else {
-      toFetch.push(sym);
+      toFetch.push(normalizedSymbol);
     }
   }
 
@@ -95,17 +155,51 @@ export async function getBaselines(symbols: string[]): Promise<Map<string, Stock
     return results;
   }
 
+  const sharedBaselines = await Promise.all(
+    toFetch.map((sym) => readSharedBaseline(sym, today)),
+  );
+  const stillMissing: string[] = [];
+
+  for (let i = 0; i < toFetch.length; i++) {
+    const baseline = sharedBaselines[i];
+    if (baseline) {
+      results.set(toFetch[i], baseline);
+    } else {
+      stillMissing.push(toFetch[i]);
+    }
+  }
+
+  if (stillMissing.length === 0) {
+    return results;
+  }
+
+  const fetchLimit = options.maxToFetch ?? stillMissing.length;
+  const limitedFetch = fetchLimit > 0 ? stillMissing.slice(0, fetchLimit) : [];
+
+  if (limitedFetch.length === 0) {
+    logger.debug(
+      `Baseline hydration skipped; ${stillMissing.length} symbol(s) not cached`,
+      { skipped: stillMissing.length, available: results.size },
+      "Baseline Service",
+    );
+    return results;
+  }
+
   logger.api(
-    `Computing baselines for ${toFetch.length} symbol(s)`,
-    { count: toFetch.length, symbols: toFetch.slice(0, 10) },
+    `Computing baselines for ${limitedFetch.length} symbol(s)`,
+    {
+      count: limitedFetch.length,
+      deferred: Math.max(0, stillMissing.length - limitedFetch.length),
+      symbols: limitedFetch.slice(0, 10),
+    },
     "Baseline Service",
-    `Fetching historical data to compute 5-day baselines for ${toFetch.length} NIFTY 50 stocks. These baselines are cached for the rest of the trading day.`,
+    `Fetching historical data to compute 5-day baselines for ${limitedFetch.length} NIFTY 50 stocks. These baselines are cached for the rest of the trading day.`,
   );
 
   // Fetch in batches to avoid overwhelming NSE
   const BATCH_SIZE = 5;
-  for (let i = 0; i < toFetch.length; i += BATCH_SIZE) {
-    const batch = toFetch.slice(i, i + BATCH_SIZE);
+  for (let i = 0; i < limitedFetch.length; i += BATCH_SIZE) {
+    const batch = limitedFetch.slice(i, i + BATCH_SIZE);
     const settled = await Promise.allSettled(
       batch.map((sym) => getBaseline(sym))
     );

--- a/src/lib/nifty50.ts
+++ b/src/lib/nifty50.ts
@@ -42,7 +42,7 @@ export const NIFTY_50_STOCKS: WatchlistStock[] = ([
   { symbol: "SUNPHARMA", name: "Sun Pharma" },
   { symbol: "TCS", name: "Tata Consultancy Services" },
   { symbol: "TATACONSUM", name: "Tata Consumer Products" },
-  { symbol: "TATAMOTORS", name: "Tata Motors" },
+  { symbol: "TMPV", name: "Tata Motors Passenger Vehicles" },
   { symbol: "TATASTEEL", name: "Tata Steel" },
   { symbol: "TECHM", name: "Tech Mahindra" },
   { symbol: "TITAN", name: "Titan Company" },

--- a/src/lib/nse-client.snapshot.spec.ts
+++ b/src/lib/nse-client.snapshot.spec.ts
@@ -1,13 +1,20 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
-const { getEquityStockIndicesMock } = vi.hoisted(() => ({
+const { getEquityStockIndicesMock, getEquityChartHistoricalDataMock, getRedisMock } = vi.hoisted(() => ({
   getEquityStockIndicesMock: vi.fn(),
+  getEquityChartHistoricalDataMock: vi.fn(),
+  getRedisMock: vi.fn(),
 }));
 
 vi.mock("stock-nse-india", () => ({
   NseIndia: vi.fn(() => ({
     getEquityStockIndices: getEquityStockIndicesMock,
+    getEquityChartHistoricalData: getEquityChartHistoricalDataMock,
   })),
+}));
+
+vi.mock("./redis", () => ({
+  getRedis: getRedisMock,
 }));
 
 vi.mock("./logger", () => ({
@@ -25,6 +32,7 @@ describe("Nifty 50 snapshot parsing contracts", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    getRedisMock.mockReturnValue(null);
     vi.useFakeTimers();
     // Monday, 06 Jan 2025 10:00 IST (inside extended hours).
     vi.setSystemTime(new Date("2025-01-06T04:30:00.000Z"));
@@ -65,6 +73,7 @@ describe("Nifty 50 snapshot parsing contracts", () => {
     expect(getEquityStockIndicesMock).toHaveBeenCalledWith("NIFTY 50");
     expect(snapshot.fetchSuccess).toBe(true);
     expect(snapshot.stale).toBe(false);
+    expect(snapshot.source).toBe("nse-index");
     expect(snapshot.stocks).toHaveLength(1);
     expect(snapshot.stocks[0]).toMatchObject({
       symbol: "INFY",
@@ -110,8 +119,274 @@ describe("Nifty 50 snapshot parsing contracts", () => {
 
     expect(second.fetchSuccess).toBe(false);
     expect(second.stale).toBe(true);
+    expect(second.source).toBe("nse-index");
     expect(second.stocks[0]?.symbol).toBe("INFY");
     expect(stats.snapshotFetchCount).toBe(2);
     expect(stats.snapshotFailCount).toBe(1);
+  });
+
+  test("uses charting intraday fallback when Nifty index metadata has no constituent rows", async () => {
+    getEquityStockIndicesMock.mockResolvedValue({
+      name: "NIFTY 50",
+      metadata: { last: 23405.6 },
+      data: [],
+    });
+    getEquityChartHistoricalDataMock.mockImplementation(() =>
+      Promise.resolve({
+        status: true,
+        data: [
+          { time: 1000, open: 99, high: 101, low: 98, close: 100, volume: 12345 },
+          { time: 2000, open: 100, high: 102, low: 99, close: 101, volume: 23456 },
+        ],
+      }),
+    );
+
+    const { getNifty50Snapshot } = await import("./nse-client");
+    const snapshot = await getNifty50Snapshot();
+
+    expect(snapshot.fetchSuccess).toBe(true);
+    expect(snapshot.stale).toBe(false);
+    expect(snapshot.source).toBe("nse-charting-intraday");
+    expect(snapshot.stocks.length).toBeGreaterThanOrEqual(40);
+    expect(snapshot.stocks[0]).toMatchObject({
+      lastPrice: 101,
+      change: 2,
+      dayHigh: 102,
+      totalTradedVolume: 35801,
+    });
+    expect(getEquityChartHistoricalDataMock).toHaveBeenCalled();
+  });
+
+  test("writes successful snapshots to fresh and last-good Upstash keys", async () => {
+    const redis = {
+      get: vi.fn(async () => null),
+      set: vi.fn(async () => "OK"),
+      createScript: vi.fn(() => ({ exec: vi.fn(async () => 1) })),
+    };
+    getRedisMock.mockReturnValue(redis);
+    getEquityStockIndicesMock.mockResolvedValue({
+      data: [
+        {
+          symbol: "INFY",
+          meta: { companyName: "Infosys Ltd" },
+          lastPrice: 1500,
+          change: 12,
+          pChange: 0.8,
+          open: 1491,
+          dayHigh: 1510,
+          dayLow: 1489,
+          previousClose: 1488,
+          totalTradedVolume: 1200000,
+          totalTradedValue: 1800000000,
+          yearHigh: 1900,
+          yearLow: 1200,
+        },
+      ],
+    });
+
+    const { getNifty50Snapshot } = await import("./nse-client");
+    const snapshot = await getNifty50Snapshot();
+
+    expect(snapshot.fetchSuccess).toBe(true);
+    expect(redis.set).toHaveBeenCalledWith(
+      "nse:nifty50Snapshot",
+      expect.objectContaining({ source: "nse-index", fetchSuccess: true }),
+      { ex: 900 },
+    );
+    expect(redis.set).toHaveBeenCalledWith(
+      "nse:nifty50Snapshot:lastGood",
+      expect.objectContaining({ source: "nse-index", fetchSuccess: true }),
+      { ex: 432000 },
+    );
+  });
+
+  test("returns shared last-good snapshots as stale when market is unavailable", async () => {
+    // Monday, 06 Jan 2025 07:30 IST (outside extended market hours).
+    vi.setSystemTime(new Date("2025-01-06T02:00:00.000Z"));
+    const lastGoodSnapshot = {
+      stocks: [
+        {
+          symbol: "INFY",
+          name: "Infosys Ltd",
+          lastPrice: 1500,
+          change: 12,
+          pChange: 0.8,
+          open: 1491,
+          dayHigh: 1510,
+          dayLow: 1489,
+          previousClose: 1488,
+          totalTradedVolume: 1200000,
+          totalTradedValue: 1800000000,
+          yearHigh: 1900,
+          yearLow: 1200,
+        },
+      ],
+      fetchedAt: "2025-01-03T10:00:00.000Z",
+      fetchSuccess: true,
+      stale: false,
+      source: "nse-index",
+    };
+    const redis = {
+      get: vi.fn(async (key: string) =>
+        key === "nse:nifty50Snapshot:lastGood" ? lastGoodSnapshot : null,
+      ),
+      set: vi.fn(async () => "OK"),
+      createScript: vi.fn(() => ({ exec: vi.fn(async () => 1) })),
+    };
+    getRedisMock.mockReturnValue(redis);
+
+    const { getNifty50Snapshot } = await import("./nse-client");
+    const snapshot = await getNifty50Snapshot();
+
+    expect(getEquityStockIndicesMock).not.toHaveBeenCalled();
+    expect(snapshot.fetchSuccess).toBe(false);
+    expect(snapshot.stale).toBe(true);
+    expect(snapshot.source).toBe("nse-index");
+    expect(snapshot.stocks[0]?.symbol).toBe("INFY");
+  });
+
+  test("does not write partial fallback snapshots to the fresh Upstash key", async () => {
+    const redis = {
+      get: vi.fn(async () => null),
+      set: vi.fn(async () => "OK"),
+      createScript: vi.fn(() => ({ exec: vi.fn(async () => 1) })),
+    };
+    getRedisMock.mockReturnValue(redis);
+    getEquityStockIndicesMock.mockResolvedValue({
+      name: "NIFTY 50",
+      metadata: { last: 23405.6 },
+      data: [],
+    });
+    getEquityChartHistoricalDataMock.mockImplementation((symbol: string) => {
+      if (symbol !== "TCS") return Promise.reject(new Error("chart unavailable"));
+      return Promise.resolve({
+        status: true,
+        data: [
+          { time: 1000, open: 99, high: 101, low: 98, close: 100, volume: 12345 },
+          { time: 2000, open: 100, high: 102, low: 99, close: 101, volume: 23456 },
+        ],
+      });
+    });
+
+    const { getNifty50Snapshot } = await import("./nse-client");
+    const snapshot = await getNifty50Snapshot();
+
+    expect(snapshot.fetchSuccess).toBe(false);
+    expect(snapshot.stale).toBe(true);
+    expect(snapshot.stocks).toHaveLength(1);
+    expect(redis.set).not.toHaveBeenCalledWith(
+      "nse:nifty50Snapshot",
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(redis.set).not.toHaveBeenCalledWith(
+      "nse:nifty50Snapshot:lastGood",
+      expect.anything(),
+    );
+  });
+
+  test("waits for a shared snapshot when another request owns the refresh lock", async () => {
+    let freshAvailable = false;
+    const sharedSnapshot = {
+      stocks: [
+        {
+          symbol: "INFY",
+          name: "Infosys Ltd",
+          lastPrice: 1500,
+          change: 12,
+          pChange: 0.8,
+          open: 1491,
+          dayHigh: 1510,
+          dayLow: 1489,
+          previousClose: 1488,
+          totalTradedVolume: 1200000,
+          totalTradedValue: 1800000000,
+          yearHigh: 1900,
+          yearLow: 1200,
+        },
+      ],
+      fetchedAt: new Date().toISOString(),
+      fetchSuccess: true,
+      stale: false,
+      source: "nse-index" as const,
+    };
+    const redis = {
+      get: vi.fn(async (key: string) => {
+        if (key === "nse:nifty50Snapshot") return freshAvailable ? sharedSnapshot : null;
+        return null;
+      }),
+      set: vi.fn(async (key: string) =>
+        key === "nse:nifty50Snapshot:refreshing" ? null : "OK",
+      ),
+      createScript: vi.fn(() => ({ exec: vi.fn(async () => 1) })),
+    };
+    getRedisMock.mockReturnValue(redis);
+
+    const { getNifty50Snapshot } = await import("./nse-client");
+    const pending = getNifty50Snapshot();
+    freshAvailable = true;
+    await vi.advanceTimersByTimeAsync(750);
+    const snapshot = await pending;
+
+    expect(snapshot.stocks[0]?.symbol).toBe("INFY");
+    expect(snapshot.fetchSuccess).toBe(true);
+    expect(getEquityStockIndicesMock).not.toHaveBeenCalled();
+  });
+
+  test("does not return empty during a cold shared refresh lock before the long wait window", async () => {
+    let freshAvailable = false;
+    const sharedSnapshot = {
+      stocks: [
+        {
+          symbol: "INFY",
+          name: "Infosys Ltd",
+          lastPrice: 1500,
+          change: 12,
+          pChange: 0.8,
+          open: 1491,
+          dayHigh: 1510,
+          dayLow: 1489,
+          previousClose: 1488,
+          totalTradedVolume: 1200000,
+          totalTradedValue: 1800000000,
+          yearHigh: 1900,
+          yearLow: 1200,
+        },
+      ],
+      fetchedAt: new Date().toISOString(),
+      fetchSuccess: true,
+      stale: false,
+      source: "nse-index" as const,
+    };
+    const redis = {
+      get: vi.fn(async (key: string) => {
+        if (key === "nse:nifty50Snapshot") return freshAvailable ? sharedSnapshot : null;
+        return null;
+      }),
+      set: vi.fn(async (key: string) =>
+        key === "nse:nifty50Snapshot:refreshing" ? null : "OK",
+      ),
+      createScript: vi.fn(() => ({ exec: vi.fn(async () => 1) })),
+    };
+    getRedisMock.mockReturnValue(redis);
+
+    const { getNifty50Snapshot } = await import("./nse-client");
+    const pending = getNifty50Snapshot();
+    let resolved = false;
+    const observed = pending.then((snapshot) => {
+      resolved = true;
+      return snapshot;
+    });
+
+    await vi.advanceTimersByTimeAsync(3_000);
+    expect(resolved).toBe(false);
+
+    freshAvailable = true;
+    await vi.advanceTimersByTimeAsync(750);
+    const snapshot = await observed;
+
+    expect(snapshot.stocks[0]?.symbol).toBe("INFY");
+    expect(snapshot.fetchSuccess).toBe(true);
+    expect(getEquityStockIndicesMock).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/nse-client.ts
+++ b/src/lib/nse-client.ts
@@ -1,6 +1,8 @@
 import { logger } from "./logger";
+import { randomUUID } from "node:crypto";
 import { NseIndia } from "stock-nse-india";
 import { isExtendedHours } from "./market-hours";
+import { NIFTY_50_STOCKS } from "./nifty50";
 import type { DayData, NiftyIndex, Nifty50StockRow, Nifty50Snapshot } from "./types";
 import { recordCall, getApiStats } from "./api-stats";
 import { getRedis } from "./redis";
@@ -456,24 +458,292 @@ export async function searchStocks(
  *
  * Cache strategy:
  *   - During market hours: 3-minute TTL (target refresh interval)
- *   - After hours: serve last-known data indefinitely (no polling)
+ *   - After hours: serve bounded last-known data as stale (no polling)
  *   - On fetch failure: return stale data with stale=true flag
  * ──────────────────────────────────────────────────────────────────── */
 
 let snapshotCache: { data: Nifty50Snapshot; fetchedAt: number } | null = null;
 const SNAPSHOT_CACHE_TTL = 3 * 60_000; // 3 minutes
+const SNAPSHOT_SHARED_CACHE_KEY = "nse:nifty50Snapshot";
+const SNAPSHOT_SHARED_LAST_GOOD_KEY = "nse:nifty50Snapshot:lastGood";
+const SNAPSHOT_SHARED_LOCK_KEY = "nse:nifty50Snapshot:refreshing";
+const SNAPSHOT_SHARED_CACHE_TTL_SECONDS = 15 * 60;
+const SNAPSHOT_SHARED_LAST_GOOD_TTL_SECONDS = 5 * 24 * 60 * 60;
+const SNAPSHOT_SHARED_LAST_GOOD_MAX_AGE_MS =
+  SNAPSHOT_SHARED_LAST_GOOD_TTL_SECONDS * 1000;
+const SNAPSHOT_SHARED_LOCK_TTL_SECONDS = 60;
+const SNAPSHOT_SHARED_LOCK_WAIT_MS = 45_000;
+const SNAPSHOT_SHARED_STALE_LOCK_WAIT_MS = 3_000;
+const SNAPSHOT_SHARED_LOCK_POLL_MS = 750;
+const SNAPSHOT_SHARED_LOCK_RELEASE_SCRIPT = `
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("DEL", KEYS[1])
+end
+return 0
+`.trim();
 
 // Tracking stats for dev panel
 let snapshotFetchCount = 0;
 let snapshotFailCount = 0;
+const NIFTY50_CHART_FALLBACK_BATCH_SIZE = 10;
+const NIFTY50_CHART_FALLBACK_MIN_ROWS = 40;
+const NIFTY50_CHART_FALLBACK_CALL_TIMEOUT_MS = 8_000;
 
 export function getNifty50SnapshotStats() {
   return {
     lastRefreshTime: snapshotCache?.data.fetchedAt ?? null,
     snapshotFetchSuccess: snapshotCache?.data.fetchSuccess ?? false,
+    snapshotSource: snapshotCache?.data.source ?? "unavailable",
     snapshotFetchCount,
     snapshotFailCount,
   };
+}
+
+function asNumber(value: unknown, fallback = 0): number {
+  const n = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function getSnapshotAgeMs(snapshot: Nifty50Snapshot): number {
+  const fetchedAt = new Date(snapshot.fetchedAt).getTime();
+  return Number.isFinite(fetchedAt) ? Date.now() - fetchedAt : Number.POSITIVE_INFINITY;
+}
+
+function isSnapshotFresh(snapshot: Nifty50Snapshot): boolean {
+  return getSnapshotAgeMs(snapshot) < SNAPSHOT_CACHE_TTL;
+}
+
+function isSuccessfulSnapshot(snapshot: Nifty50Snapshot): boolean {
+  return snapshot.fetchSuccess && !snapshot.stale && snapshot.stocks.length > 0;
+}
+
+function isFreshSuccessfulSnapshot(snapshot: Nifty50Snapshot): boolean {
+  return isSuccessfulSnapshot(snapshot) && isSnapshotFresh(snapshot);
+}
+
+function isUsableLastGoodSnapshot(snapshot: Nifty50Snapshot): boolean {
+  return (
+    isSuccessfulSnapshot(snapshot)
+    && getSnapshotAgeMs(snapshot) < SNAPSHOT_SHARED_LAST_GOOD_MAX_AGE_MS
+  );
+}
+
+function markSnapshotUnavailable(snapshot: Nifty50Snapshot): Nifty50Snapshot {
+  return { ...snapshot, stale: true, fetchSuccess: false };
+}
+
+async function readSharedNifty50Snapshot(
+  key = SNAPSHOT_SHARED_CACHE_KEY,
+): Promise<Nifty50Snapshot | null> {
+  const r = getRedis();
+  if (!r) return null;
+
+  try {
+    const snapshot = await r.get<Nifty50Snapshot>(key);
+    if (!snapshot?.fetchedAt || !Array.isArray(snapshot.stocks)) return null;
+    return snapshot;
+  } catch (error) {
+    logger.warn(
+      "Nifty 50 shared snapshot cache read failed",
+      { error, key },
+      "Nifty50 Snapshot",
+    );
+    return null;
+  }
+}
+
+async function writeSharedNifty50Snapshot(snapshot: Nifty50Snapshot): Promise<void> {
+  const r = getRedis();
+  if (!r) return;
+  if (!isSuccessfulSnapshot(snapshot)) return;
+
+  try {
+    await Promise.all([
+      r.set(SNAPSHOT_SHARED_CACHE_KEY, snapshot, { ex: SNAPSHOT_SHARED_CACHE_TTL_SECONDS }),
+      r.set(SNAPSHOT_SHARED_LAST_GOOD_KEY, snapshot, { ex: SNAPSHOT_SHARED_LAST_GOOD_TTL_SECONDS }),
+    ]);
+  } catch (error) {
+    logger.warn(
+      "Nifty 50 shared snapshot cache write failed",
+      { error },
+      "Nifty50 Snapshot",
+    );
+  }
+}
+
+async function readSharedLastGoodNifty50Snapshot(): Promise<Nifty50Snapshot | null> {
+  const lastGood = await readSharedNifty50Snapshot(SNAPSHOT_SHARED_LAST_GOOD_KEY);
+  return lastGood && isUsableLastGoodSnapshot(lastGood) ? lastGood : null;
+}
+
+async function waitForSharedNifty50Snapshot(timeoutMs: number): Promise<Nifty50Snapshot | null> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    await sleep(Math.min(SNAPSHOT_SHARED_LOCK_POLL_MS, Math.max(0, deadline - Date.now())));
+    const snapshot = await readSharedNifty50Snapshot();
+    if (snapshot && isFreshSuccessfulSnapshot(snapshot)) {
+      return snapshot;
+    }
+  }
+
+  return null;
+}
+
+type SharedRefreshLock =
+  | { status: "acquired"; token: string }
+  | { status: "busy" | "unavailable"; token?: never };
+
+async function acquireSharedNifty50RefreshLock(): Promise<SharedRefreshLock> {
+  const r = getRedis();
+  if (!r) return { status: "unavailable" };
+
+  try {
+    const token = randomUUID();
+    const locked = await r.set(SNAPSHOT_SHARED_LOCK_KEY, token, {
+      nx: true,
+      ex: SNAPSHOT_SHARED_LOCK_TTL_SECONDS,
+    });
+    return locked === "OK" ? { status: "acquired", token } : { status: "busy" };
+  } catch (error) {
+    logger.warn(
+      "Nifty 50 shared refresh lock failed; proceeding without shared lock",
+      { error },
+      "Nifty50 Snapshot",
+    );
+    return { status: "unavailable" };
+  }
+}
+
+async function releaseSharedNifty50RefreshLock(token: string): Promise<void> {
+  const r = getRedis();
+  if (!r) return;
+
+  try {
+    const script = r.createScript<number>(SNAPSHOT_SHARED_LOCK_RELEASE_SCRIPT);
+    await script.exec([SNAPSHOT_SHARED_LOCK_KEY], [token]);
+  } catch (error) {
+    logger.warn(
+      "Nifty 50 shared refresh lock release failed",
+      { error },
+      "Nifty50 Snapshot",
+    );
+  }
+}
+
+async function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timeout = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+type ChartingCandle = {
+  open?: unknown;
+  high?: unknown;
+  low?: unknown;
+  close?: unknown;
+  volume?: unknown;
+  time?: unknown;
+};
+
+async function getNifty50ChartFallbackRows(): Promise<Nifty50StockRow[]> {
+  recordCall("api", "getNifty50ChartFallback");
+  const rows: Nifty50StockRow[] = [];
+  const failedSymbols: string[] = [];
+
+  for (let i = 0; i < NIFTY_50_STOCKS.length; i += NIFTY50_CHART_FALLBACK_BATCH_SIZE) {
+    const batch = NIFTY_50_STOCKS.slice(i, i + NIFTY50_CHART_FALLBACK_BATCH_SIZE);
+    const results = await Promise.allSettled(
+      batch.map(async (stock) => {
+        const response = await withTimeout(
+          getNse().getEquityChartHistoricalData(
+            stock.symbol,
+            undefined,
+            undefined,
+            "Equity",
+            "I",
+            "5",
+          ),
+          NIFTY50_CHART_FALLBACK_CALL_TIMEOUT_MS,
+          `Nifty 50 charting fallback ${stock.symbol}`,
+        );
+        const candles = (Array.isArray(response?.data) ? response.data : [])
+          .map((candle: ChartingCandle) => ({
+            open: asNumber(candle.open),
+            high: asNumber(candle.high),
+            low: asNumber(candle.low),
+            close: asNumber(candle.close),
+            volume: asNumber(candle.volume),
+            time: asNumber(candle.time),
+          }))
+          .filter((candle) => candle.close > 0)
+          .sort((a, b) => a.time - b.time);
+
+        if (candles.length === 0) {
+          throw new Error(`No charting candles returned for ${stock.symbol}`);
+        }
+
+        const first = candles[0];
+        const last = candles[candles.length - 1];
+        const open = first.open > 0 ? first.open : first.close;
+        const lastPrice = last.close;
+        const change = lastPrice - open;
+        const pChange = open > 0 ? (change / open) * 100 : 0;
+        const dayHigh = Math.max(...candles.map((candle) => candle.high || candle.close));
+        const dayLow = Math.min(...candles.map((candle) => candle.low || candle.close));
+        const volume = candles.reduce((sum, candle) => sum + candle.volume, 0);
+
+        return {
+          symbol: stock.symbol,
+          name: stock.name,
+          lastPrice,
+          change,
+          pChange,
+          open,
+          dayHigh,
+          dayLow,
+          previousClose: open,
+          totalTradedVolume: volume,
+          totalTradedValue: volume * lastPrice,
+          yearHigh: 0,
+          yearLow: 0,
+        } satisfies Nifty50StockRow;
+      }),
+    );
+
+    for (let j = 0; j < results.length; j++) {
+      const result = results[j];
+      if (result.status === "fulfilled" && result.value.lastPrice > 0) {
+        rows.push(result.value);
+      } else if (result.status === "fulfilled") {
+        failedSymbols.push(result.value.symbol);
+      } else {
+        failedSymbols.push(batch[j]?.symbol ?? "unknown");
+      }
+    }
+  }
+
+  if (failedSymbols.length > 0) {
+    logger.warn(
+      `Nifty 50 charting fallback missed ${failedSymbols.length} symbol(s)`,
+      { failedSymbols },
+      "Nifty50 Snapshot",
+    );
+  }
+
+  return rows;
 }
 
 export async function getNifty50Snapshot(): Promise<Nifty50Snapshot> {
@@ -483,11 +753,55 @@ export async function getNifty50Snapshot(): Promise<Nifty50Snapshot> {
     return snapshotCache.data;
   }
 
-  if (!isExtendedHours() || await isHolidayToday()) {
+  const marketUnavailable = !isExtendedHours() || await isHolidayToday();
+  if (marketUnavailable) {
     if (snapshotCache) {
       recordCall("cache", "getNifty50Snapshot");
       return snapshotCache.data;
     }
+  }
+
+  const sharedSnapshot = await readSharedNifty50Snapshot();
+  const lastGoodSnapshot = sharedSnapshot && isUsableLastGoodSnapshot(sharedSnapshot)
+    ? sharedSnapshot
+    : await readSharedLastGoodNifty50Snapshot();
+
+  if (sharedSnapshot && isFreshSuccessfulSnapshot(sharedSnapshot)) {
+    recordCall("cache", "getNifty50Snapshot");
+    snapshotCache = { data: sharedSnapshot, fetchedAt: Date.now() };
+    return sharedSnapshot;
+  }
+
+  if (marketUnavailable && lastGoodSnapshot) {
+    recordCall("cache", "getNifty50Snapshot");
+    const staleLastGood = markSnapshotUnavailable(lastGoodSnapshot);
+    snapshotCache = { data: staleLastGood, fetchedAt: Date.now() };
+    return staleLastGood;
+  }
+
+  const sharedLock = await acquireSharedNifty50RefreshLock();
+  if (sharedLock.status === "busy") {
+    const staleFallback = lastGoodSnapshot
+      ?? (sharedSnapshot?.stocks.length ? sharedSnapshot : null);
+    const waitMs = staleFallback
+      ? SNAPSHOT_SHARED_STALE_LOCK_WAIT_MS
+      : SNAPSHOT_SHARED_LOCK_WAIT_MS;
+    const refreshedSharedSnapshot = await waitForSharedNifty50Snapshot(waitMs);
+    if (refreshedSharedSnapshot) {
+      recordCall("cache", "getNifty50Snapshot");
+      snapshotCache = { data: refreshedSharedSnapshot, fetchedAt: Date.now() };
+      return refreshedSharedSnapshot;
+    }
+    if (staleFallback) {
+      return markSnapshotUnavailable(staleFallback);
+    }
+    return {
+      stocks: [],
+      fetchedAt: new Date().toISOString(),
+      fetchSuccess: false,
+      stale: true,
+      source: "unavailable",
+    };
   }
 
   recordCall("api", "getNifty50Snapshot");
@@ -502,6 +816,26 @@ export async function getNifty50Snapshot(): Promise<Nifty50Snapshot> {
     const dataArray = raw?.data;
 
     if (!Array.isArray(dataArray) || dataArray.length === 0) {
+      const fallbackRows = await getNifty50ChartFallbackRows();
+      if (fallbackRows.length > 0) {
+        const fetchSuccess = fallbackRows.length >= NIFTY50_CHART_FALLBACK_MIN_ROWS;
+        const snapshot: Nifty50Snapshot = {
+          stocks: fallbackRows,
+          fetchedAt: new Date().toISOString(),
+          fetchSuccess,
+          stale: !fetchSuccess,
+          source: "nse-charting-intraday",
+        };
+        snapshotCache = { data: snapshot, fetchedAt: Date.now() };
+        await writeSharedNifty50Snapshot(snapshot);
+        logger[fetchSuccess ? "info" : "warn"](
+          `Nifty 50 charting fallback: ${fallbackRows.length}/${NIFTY_50_STOCKS.length} stocks`,
+          { stockCount: fallbackRows.length, fetchSuccess },
+          "Nifty50 Snapshot",
+        );
+        return snapshot;
+      }
+
       logger.warn(
         "Nifty 50 snapshot: no data array in response",
         { keys: raw ? Object.keys(raw) : null },
@@ -511,7 +845,13 @@ export async function getNifty50Snapshot(): Promise<Nifty50Snapshot> {
       if (snapshotCache) {
         return { ...snapshotCache.data, stale: true, fetchSuccess: false };
       }
-      return { stocks: [], fetchedAt: new Date().toISOString(), fetchSuccess: false, stale: true };
+      return {
+        stocks: [],
+        fetchedAt: new Date().toISOString(),
+        fetchSuccess: false,
+        stale: true,
+        source: "unavailable",
+      };
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -540,9 +880,11 @@ export async function getNifty50Snapshot(): Promise<Nifty50Snapshot> {
       fetchedAt: new Date().toISOString(),
       fetchSuccess: true,
       stale: false,
+      source: "nse-index",
     };
 
     snapshotCache = { data: snapshot, fetchedAt: Date.now() };
+    await writeSharedNifty50Snapshot(snapshot);
 
     logger.debug(
       `Nifty 50 snapshot: ${stocks.length} stocks fetched`,
@@ -563,6 +905,22 @@ export async function getNifty50Snapshot(): Promise<Nifty50Snapshot> {
     if (snapshotCache) {
       return { ...snapshotCache.data, stale: true, fetchSuccess: false };
     }
-    return { stocks: [], fetchedAt: new Date().toISOString(), fetchSuccess: false, stale: true };
+    if (lastGoodSnapshot) {
+      return markSnapshotUnavailable(lastGoodSnapshot);
+    }
+    if (sharedSnapshot?.stocks.length) {
+      return markSnapshotUnavailable(sharedSnapshot);
+    }
+    return {
+      stocks: [],
+      fetchedAt: new Date().toISOString(),
+      fetchSuccess: false,
+      stale: true,
+      source: "unavailable",
+    };
+  } finally {
+    if (sharedLock.status === "acquired") {
+      await releaseSharedNifty50RefreshLock(sharedLock.token);
+    }
   }
 }

--- a/src/lib/store.nifty50-stats.spec.ts
+++ b/src/lib/store.nifty50-stats.spec.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const { redisMap } = vi.hoisted(() => ({
+  redisMap: new Map<string, unknown>(),
+}));
+
+vi.mock("./redis", () => ({
+  getRedis: () => ({
+    get: async <T,>(key: string) => (redisMap.get(key) as T | undefined) ?? null,
+    set: async (key: string, value: unknown) => {
+      redisMap.set(key, value);
+      return "OK";
+    },
+  }),
+}));
+
+import { getNifty50PersistentStats } from "./store";
+
+describe("Nifty 50 persistent stats", () => {
+  beforeEach(() => {
+    redisMap.clear();
+  });
+
+  test("merges defaults into older Redis stats that do not have snapshot source", async () => {
+    redisMap.set("nse:nifty50Stats", {
+      lastRefreshTime: "2026-06-03T10:00:00.000Z",
+      snapshotFetchSuccess: true,
+      snapshotFetchCount: 4,
+      snapshotFailCount: 1,
+    });
+
+    await expect(getNifty50PersistentStats()).resolves.toEqual({
+      lastRefreshTime: "2026-06-03T10:00:00.000Z",
+      snapshotFetchSuccess: true,
+      snapshotFetchCount: 4,
+      snapshotFailCount: 1,
+      snapshotSource: "unavailable",
+    });
+  });
+});

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -261,6 +261,7 @@ const DEFAULT_NIFTY50_STATS: Nifty50PersistentStats = {
   snapshotFetchSuccess: false,
   snapshotFetchCount: 0,
   snapshotFailCount: 0,
+  snapshotSource: "unavailable",
 };
 
 let memNifty50Stats: Nifty50PersistentStats | null = null;
@@ -269,7 +270,7 @@ export async function getNifty50PersistentStats(): Promise<Nifty50PersistentStat
   const r = getRedis();
   if (r) {
     const data = await r.get<Nifty50PersistentStats>(NIFTY50_STATS_KEY);
-    return data ?? { ...DEFAULT_NIFTY50_STATS };
+    return data ? { ...DEFAULT_NIFTY50_STATS, ...data } : { ...DEFAULT_NIFTY50_STATS };
   }
   return memNifty50Stats ?? { ...DEFAULT_NIFTY50_STATS };
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -136,9 +136,14 @@ export interface ScanMeta {
   alertsFired: string[];
 }
 
-/* ── Nifty 50 Table (snapshot from getEquityStockIndices) ─────────── */
+/* ── Nifty 50 Table (snapshot from NSE live data) ─────────────────── */
 
-/** A single stock row returned by NSE's getEquityStockIndices("NIFTY 50") */
+export type Nifty50SnapshotSource =
+  | "nse-index"
+  | "nse-charting-intraday"
+  | "unavailable";
+
+/** A single Nifty 50 stock row from NSE live index or quote APIs */
 export interface Nifty50StockRow {
   symbol: string;
   name: string;
@@ -161,6 +166,7 @@ export interface Nifty50Snapshot {
   fetchedAt: string;
   fetchSuccess: boolean;
   stale: boolean;
+  source: Nifty50SnapshotSource;
 }
 
 export interface StockBaseline {
@@ -186,7 +192,7 @@ export interface BreakoutDiscovery {
   volumeBreakPercent: number;
   /** true = baseline data is unreliable or missing */
   baselineUnavailable: boolean;
-  /** true = live price data fetch failed; breakout is possible but unconfirmed */
+  /** true = freshness/source trust is degraded; breakout is possible but unconfirmed */
   possibleBreakout: boolean;
 }
 
@@ -240,6 +246,7 @@ export interface Nifty50PersistentStats {
   snapshotFetchSuccess: boolean;
   snapshotFetchCount: number;
   snapshotFailCount: number;
+  snapshotSource: Nifty50SnapshotSource;
 }
 
 export type AlertRequestStatus = "pending" | "issue_created" | "pr_created" | "implemented" | "rejected";

--- a/src/test-utils/fixtures.ts
+++ b/src/test-utils/fixtures.ts
@@ -37,6 +37,7 @@ export function makeSnapshot(
     fetchedAt: "2025-01-06T10:30:00.000Z",
     fetchSuccess: true,
     stale: false,
+    source: "nse-index",
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

- upgrade `stock-nse-india` to 1.4.0 / Node.js 20 and document the runtime/data-source change
- add Redis-backed Nifty 50 snapshot, last-good snapshot, refresh lock, and baseline cache paths for Upstash production
- downgrade fallback charting data to unconfirmed signals so it cannot create confirmed breakout alerts
- persist and surface snapshot source metadata in state/dev dashboard responses
- add regression coverage for Redis baselines, shared snapshots, cold refresh locks, fallback source semantics, and older persisted stats records

## Root Cause

The Nifty 50 table could lose reliable live index rows and fall back to local/process-only state or charting data without enough source awareness. In production serverless/Upstash, process memory is not durable across invocations, and fallback snapshots/signals needed to be shared and clearly marked so stale or degraded data does not look confirmed.

## Impact

Production uses Upstash when `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` are configured. Local development still no-ops Redis-backed paths or uses existing local fallbacks when those env vars are absent. The PR avoids local-only storage bandages and keeps the production cache/state path Redis-first.

## Validation

- `node node_modules/vitest/vitest.mjs run src/lib/nse-client.snapshot.spec.ts` passed: 1 file, 8 tests
- `node node_modules/vitest/vitest.mjs run` passed: 17 files, 67 tests
- `node node_modules/typescript/bin/tsc --noEmit` passed
- `git diff --check` passed with only Git LF-to-CRLF warnings