### PR TITLE
[codex] Avoid caching partial Nifty fallback snapshots

### DIFF
--- a/src/lib/nse-client.snapshot.spec.ts
+++ b/src/lib/nse-client.snapshot.spec.ts
@@ -283,6 +283,13 @@ describe("Nifty 50 snapshot parsing contracts", () => {
       "nse:nifty50Snapshot:lastGood",
       expect.anything(),
     );
+
+    getEquityStockIndicesMock.mockClear();
+    getEquityChartHistoricalDataMock.mockClear();
+    await getNifty50Snapshot();
+
+    expect(getEquityStockIndicesMock).toHaveBeenCalledWith("NIFTY 50");
+    expect(getEquityChartHistoricalDataMock).toHaveBeenCalled();
   });
 
   test("waits for a shared snapshot when another request owns the refresh lock", async () => {

--- a/src/lib/nse-client.ts
+++ b/src/lib/nse-client.ts
@@ -826,8 +826,10 @@ export async function getNifty50Snapshot(): Promise<Nifty50Snapshot> {
           stale: !fetchSuccess,
           source: "nse-charting-intraday",
         };
-        snapshotCache = { data: snapshot, fetchedAt: Date.now() };
-        await writeSharedNifty50Snapshot(snapshot);
+        if (fetchSuccess) {
+          snapshotCache = { data: snapshot, fetchedAt: Date.now() };
+          await writeSharedNifty50Snapshot(snapshot);
+        }
         logger[fetchSuccess ? "info" : "warn"](
           `Nifty 50 charting fallback: ${fallbackRows.length}/${NIFTY_50_STOCKS.length} stocks`,
           { stockCount: fallbackRows.length, fetchSuccess },


### PR DESCRIPTION
## Summary

- avoid storing partial charting fallback snapshots in the per-instance `snapshotCache`
- keep caching only successful charting fallback snapshots that meet the minimum row threshold
- extend the snapshot regression test so a second call retries NSE instead of serving a partial fallback from memory

## Root Cause

The Redis fresh/last-good writes already skipped partial fallback snapshots, but the local process cache still stored them. Because the fast path returns any fresh `snapshotCache` entry, a transient 1-39 row fallback could keep serving an incomplete Nifty 50 table for up to 3 minutes and skip a fresh primary retry.

## Impact

Partial fallback rows are still returned to the request that produced them, but they are no longer cached in memory. The next request can retry the primary NSE index path immediately if NSE recovers.

## Validation

- `node node_modules/vitest/vitest.mjs run src/lib/nse-client.snapshot.spec.ts` passed: 1 file, 8 tests
- `node node_modules/vitest/vitest.mjs run` passed: 17 files, 67 tests
- `node node_modules/typescript/bin/tsc --noEmit` passed