### PR TITLE
chore: place NSE tracker in maintenance mode

### DIFF
--- a/src/app/maintenance/page.tsx
+++ b/src/app/maintenance/page.tsx
@@ -1,0 +1,58 @@
+import type { Metadata } from "next";
+import { MAINTENANCE_MESSAGE } from "@/maintenance";
+
+export const metadata: Metadata = {
+  title: "Maintenance | Tickzy",
+  description: MAINTENANCE_MESSAGE,
+  robots: { index: false, follow: false },
+};
+
+export default function MaintenancePage() {
+  return (
+    <main className="flex min-h-screen items-center justify-center px-6 py-16">
+      <section className="card-elevated relative w-full max-w-lg overflow-hidden rounded-3xl bg-[var(--surface-raised)] px-8 py-12 text-center ring-1 ring-[var(--surface-border)] sm:px-12">
+        <div
+          aria-hidden="true"
+          className="absolute inset-x-12 top-0 h-px bg-gradient-to-r from-transparent via-accent/60 to-transparent"
+        />
+
+        <div className="mb-7 flex justify-center">
+          <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-accent/10 text-accent ring-1 ring-accent/20">
+            <svg
+              width="30"
+              height="30"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.75"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M12 2v4" />
+              <path d="m16.24 7.76 2.83-2.83" />
+              <path d="M18 12h4" />
+              <path d="m16.24 16.24 2.83 2.83" />
+              <path d="M12 18v4" />
+              <path d="m7.76 16.24-2.83 2.83" />
+              <path d="M6 12H2" />
+              <path d="m7.76 7.76-2.83-2.83" />
+            </svg>
+          </div>
+        </div>
+
+        <p className="mb-3 text-xs font-semibold uppercase tracking-[0.24em] text-accent">
+          Tickzy
+        </p>
+        <h1 className="font-display text-3xl font-bold text-text-primary">
+          Maintenance in progress
+        </h1>
+        <p className="mx-auto mt-4 max-w-sm text-sm leading-6 text-text-secondary">
+          {MAINTENANCE_MESSAGE}
+        </p>
+        <p className="mt-6 text-xs text-text-muted">
+          Thank you for your patience.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/src/maintenance.spec.tsx
+++ b/src/maintenance.spec.tsx
@@ -1,0 +1,51 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+import MaintenancePage from "@/app/maintenance/page";
+import {
+  getMaintenanceDisposition,
+  MAINTENANCE_MESSAGE,
+  MAINTENANCE_MODE,
+} from "@/maintenance";
+
+describe("maintenance policy", () => {
+  test("keeps maintenance mode active", () => {
+    expect(MAINTENANCE_MODE).toBe(true);
+  });
+
+  test.each(["/maintenance", "/maintenance/"])(
+    "allows the maintenance page at %s",
+    (pathname) => {
+      expect(getMaintenanceDisposition(pathname)).toBe(
+        "allow-maintenance-page",
+      );
+    },
+  );
+
+  test.each([
+    "/api",
+    "/api/state",
+    "/api/auth",
+    "/api/register",
+    "/api/admin/lockdown",
+    "/api/admin/registrations",
+  ])("makes %s unavailable", (pathname) => {
+    expect(getMaintenanceDisposition(pathname)).toBe("service-unavailable");
+  });
+
+  test.each(["/", "/login", "/lockdown", "/dev", "/analyze/INFY"])(
+    "redirects the page surface %s",
+    (pathname) => {
+      expect(getMaintenanceDisposition(pathname)).toBe("redirect");
+    },
+  );
+
+  test("renders neutral public copy", () => {
+    const html = renderToStaticMarkup(<MaintenancePage />);
+
+    expect(html).toContain("Maintenance in progress");
+    expect(html).toContain(MAINTENANCE_MESSAGE);
+    expect(html.toLowerCase()).not.toMatch(
+      /redis|upstash|migration|infrastructure|outage/,
+    );
+  });
+});

--- a/src/maintenance.ts
+++ b/src/maintenance.ts
@@ -1,0 +1,28 @@
+export const MAINTENANCE_PATH = "/maintenance";
+export const MAINTENANCE_MESSAGE =
+  "This application is currently under maintenance. Please check back soon.";
+export const MAINTENANCE_RETRY_AFTER_SECONDS = 3600;
+export const MAINTENANCE_MODE = true;
+
+export type MaintenanceDisposition =
+  | "allow-maintenance-page"
+  | "service-unavailable"
+  | "redirect";
+
+export const getMaintenanceDisposition = (
+  pathname: string,
+): MaintenanceDisposition | null => {
+  if (!MAINTENANCE_MODE) {
+    return null;
+  }
+
+  if (pathname === MAINTENANCE_PATH || pathname === `${MAINTENANCE_PATH}/`) {
+    return "allow-maintenance-page";
+  }
+
+  if (pathname === "/api" || pathname.startsWith("/api/")) {
+    return "service-unavailable";
+  }
+
+  return "redirect";
+};

--- a/src/proxy.spec.ts
+++ b/src/proxy.spec.ts
@@ -1,0 +1,75 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  MAINTENANCE_MESSAGE,
+  MAINTENANCE_RETRY_AFTER_SECONDS,
+} from "@/maintenance";
+
+const mocks = vi.hoisted(() => ({
+  getSecurityState: vi.fn(),
+  isLockdownExpired: vi.fn(),
+  setSecurityState: vi.fn(),
+}));
+
+vi.mock("@/lib/lockdown", () => ({
+  getSecurityState: mocks.getSecurityState,
+  isLockdownExpired: mocks.isLockdownExpired,
+  setSecurityState: mocks.setSecurityState,
+}));
+
+import { proxy } from "./proxy";
+
+const makeRequest = (pathname: string) =>
+  new NextRequest(new URL(pathname, "https://tickzy.dev"));
+
+describe("maintenance request gate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test.each([
+    "/api/state",
+    "/api/auth",
+    "/api/register",
+    "/api/admin/sessions",
+    "/api/admin/registrations",
+  ])("returns a neutral 503 for %s without reading private state", async (path) => {
+    const response = await proxy(makeRequest(path));
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      error: MAINTENANCE_MESSAGE,
+    });
+    expect(response.headers.get("cache-control")).toBe(
+      "no-store, max-age=0",
+    );
+    expect(response.headers.get("retry-after")).toBe(
+      String(MAINTENANCE_RETRY_AFTER_SECONDS),
+    );
+    expect(mocks.getSecurityState).not.toHaveBeenCalled();
+  });
+
+  test.each(["/", "/login", "/lockdown", "/dev", "/analyze/INFY"])(
+    "redirects %s without reading private state",
+    async (path) => {
+      const response = await proxy(makeRequest(path));
+
+      expect(response.status).toBe(307);
+      expect(response.headers.get("location")).toBe(
+        "https://tickzy.dev/maintenance",
+      );
+      expect(response.headers.get("cache-control")).toBe(
+        "no-store, max-age=0",
+      );
+      expect(mocks.getSecurityState).not.toHaveBeenCalled();
+    },
+  );
+
+  test("allows only the maintenance page through without reading private state", async () => {
+    const response = await proxy(makeRequest("/maintenance"));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-middleware-next")).toBe("1");
+    expect(mocks.getSecurityState).not.toHaveBeenCalled();
+  });
+});

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -4,6 +4,12 @@ import {
   isLockdownExpired,
   setSecurityState,
 } from "@/lib/lockdown";
+import {
+  getMaintenanceDisposition,
+  MAINTENANCE_MESSAGE,
+  MAINTENANCE_PATH,
+  MAINTENANCE_RETRY_AFTER_SECONDS,
+} from "@/maintenance";
 
 /* ── Token generation (must match auth route) ──────────────────────── */
 
@@ -30,6 +36,33 @@ async function computeToken(epoch: number): Promise<string> {
 
 export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
+  const maintenanceDisposition = getMaintenanceDisposition(pathname);
+
+  if (maintenanceDisposition !== null) {
+    if (maintenanceDisposition === "allow-maintenance-page") {
+      return NextResponse.next();
+    }
+
+    if (maintenanceDisposition === "service-unavailable") {
+      return NextResponse.json(
+        { error: MAINTENANCE_MESSAGE },
+        {
+          status: 503,
+          headers: {
+            "Cache-Control": "no-store, max-age=0",
+            "Retry-After": String(MAINTENANCE_RETRY_AFTER_SECONDS),
+          },
+        },
+      );
+    }
+
+    const maintenanceResponse = NextResponse.redirect(
+      new URL(MAINTENANCE_PATH, request.url),
+    );
+    maintenanceResponse.headers.set("Cache-Control", "no-store, max-age=0");
+    maintenanceResponse.headers.set("X-Robots-Tag", "noindex, nofollow");
+    return maintenanceResponse;
+  }
 
   // Public paths — no auth required
   if (


### PR DESCRIPTION
## Summary

- add a neutral maintenance page
- direct visitors to it while application work continues
- make normal application requests temporarily unavailable
- add focused coverage for maintenance behavior

## User impact

The application is temporarily unavailable while development work continues. Visitors see: "This application is currently under maintenance. Please check back soon."

## Verification

- Full automated test suite: 93 passed
- Type checking: passed
- Production build: passed
- Local maintenance behavior smoke check: passed